### PR TITLE
feat(zonecog): add AGI Studio autonomous agent orchestration

### DIFF
--- a/.goals/zonecog-agi-studio/goal.md
+++ b/.goals/zonecog-agi-studio/goal.md
@@ -1,0 +1,162 @@
+# Goal: ZoneCog AGI Studio — Agent-Zero-style autonomous agent orchestration
+
+## User Request
+
+"implement zonecog agi studio" with context `/agent-zero [ "zonecog" ]` — build an
+Agent-Zero-inspired AGI Studio for the ZoneCog cognitive workbench.
+
+## Refined Goal
+
+Implement an **AGI Studio** subsystem for the ZoneCog cognitive workbench: a new
+`IAgiStudioService` that provides Agent-Zero-style hierarchical autonomous agents.
+An Agent-Zero model means: a root studio agent receives a goal from the user; any
+agent can **spawn subordinate agents** to delegate decomposed subtasks (forming a
+superior/subordinate tree); agents communicate via **direct inter-agent messages**
+(superior→subordinate task assignment, subordinate→superior result reporting);
+agents solve tasks using **tools** — the existing specialized cognitive agents
+(SQL Analyzer, Schema Reasoner, Performance Advisor, Data Pattern), LLM completion
+via `ILLMProviderService`, and memory recall/save; each agent keeps **agent-local
+memory** in addition to the shared cognitive workspace; and every run persists its
+state to the hypergraph. The Studio is surfaced in the workbench via a new
+"AGI Studio" view in the existing Zone-Cog panel plus Command Palette actions to
+launch a goal, inspect the agent tree, and stop a run.
+
+## Acceptance Criteria
+
+- [ ] Criterion 1 — **Service contract**: A new interface file
+      `src/sql/workbench/services/zonecog/common/agiStudio.ts` defines
+      `IAgiStudioService` (via `createDecorator`) with types for:
+      `StudioAgent` (id, name, role, superiorId, subordinateIds, status, depth,
+      systemPrompt, createdAt, agent-local memory), `AgentMessage` (id, fromAgentId,
+      toAgentId, messageType at minimum 'task-assignment' | 'result-report' |
+      'status-update', content, timestamp), `StudioRun` (id, goal, rootAgentId,
+      status 'running' | 'completed' | 'failed' | 'stopped', startTime, endTime?,
+      result?), `AgentToolCall` (toolId, input, output, success, durationMs), and
+      events (`onDidChangeRun`, `onDidSpawnAgent`, `onDidSendMessage` or equivalent).
+- [ ] Criterion 2 — **Hierarchical spawning & delegation**: The implementation
+      `browser/agiStudioService.ts` lets an agent spawn subordinate agents
+      (`spawnSubordinate`-style API) forming a tree rooted at agent depth 0; a
+      configurable max depth (default ≥ 2) and max total agents cap prevent runaway
+      growth; subordinates receive task assignments as `AgentMessage`s and report
+      results back to their superior as `AgentMessage`s; the full message log per
+      run is queryable.
+- [ ] Criterion 3 — **Autonomous run loop with tools**: `startRun(goal)` executes
+      an autonomous loop: the root agent decomposes the goal (via
+      `ILLMProviderService.complete()` — never direct API calls; built-in fallback
+      must work with no API keys), delegates subtasks to spawned subordinates,
+      subordinates execute using at least 4 registered tools that wrap the existing
+      specialized agents (`ISQLAnalyzerAgent`, `ISchemaReasonerAgent`,
+      `IPerformanceAdvisorAgent`, `IDataPatternAgent`) plus an LLM-reasoning tool
+      and memory tools (save/recall drawing on agent-local memory and
+      `ICognitiveWorkspaceService` episodic memory); tool invocations are recorded
+      as `AgentToolCall`s; the run completes with a synthesized result on the
+      `StudioRun`; `stopRun()` halts a running run and marks it 'stopped'.
+- [ ] Criterion 4 — **ZoneCog integration**: All studio activity records membrane
+      activity (`cerebral` for reasoning/decomposition, `somatic` for tool/LLM
+      calls, `autonomic` for health/guard checks); runs, agents, and messages are
+      persisted as hypergraph nodes following the EchoCog `HypergraphNode` schema
+      (id, node_type, content, links, metadata, salience_score) with typed links
+      connecting run → agents → messages; the service is registered in
+      `browser/zonecog.contribution.ts` via
+      `registerSingleton(IAgiStudioService, AgiStudioService, InstantiationType.Eager)`.
+- [ ] Criterion 5 — **Studio UI**: A new `AgiStudioView` (ViewPane subclass, DOM
+      built with `$`/`append`/`clearNode`, `localize()` for all strings,
+      `zonecog-*` CSS classes) is registered in the existing Zone-Cog panel view
+      container (`workbench.view.zonecog`) in `zonecogPanel.contribution.ts`,
+      rendering current run status, the agent hierarchy (tree with roles/status),
+      and recent agent messages, refreshing reactively via service events.
+- [ ] Criterion 6 — **Command Palette actions**: At least 3 new `Action2` actions
+      registered in `zonecogActions.contribution.ts` under the existing Zone-Cog
+      category: `zonecog.agiStudio.startRun` (prompts for a goal via quick input),
+      `zonecog.agiStudio.showStatus` (shows run/agent-tree summary), and
+      `zonecog.agiStudio.stopRun`.
+- [ ] Criterion 7 — **Tests**: A new
+      `test/browser/agiStudioService.test.ts` suite using
+      `TestInstantiationService` + `NullLogService` with **real instances** of
+      dependency services (not mocks), covering: service init, run lifecycle
+      (start → completed with non-empty result), hierarchical spawning (subordinate
+      has correct superiorId/depth; caps enforced), inter-agent messaging (task
+      assignment + result report present in message log), tool registry (≥ 6 tools;
+      tool calls recorded), agent-local memory (save + recall), hypergraph
+      persistence (nodes with expected node_types exist), membrane activity, event
+      firing, and stopRun behavior. Minimum 12 test cases.
+- [ ] Criterion 8 — **Quality gate**: `tsc --noEmit -p src/tsconfig.json` reports
+      **zero errors mentioning "zonecog" or "agiStudio"** and no increase in total
+      baseline error lines (baseline: 16 pre-existing error lines in
+      node_modules / vs platform test files caused by `--ignore-scripts` install;
+      those are out of scope).
+
+## Scope Boundaries
+
+**In scope:**
+- New files: `common/agiStudio.ts`, `browser/agiStudioService.ts`,
+  `test/browser/agiStudioService.test.ts`, and an `AgiStudioView` (either a new
+  view file under `contrib/zonecog/browser/` or added to an existing views file).
+- Edits to: `browser/zonecog.contribution.ts` (registration),
+  `contrib/zonecog/browser/zonecogPanel.contribution.ts` (view registration),
+  `contrib/zonecog/browser/zonecogActions.contribution.ts` (actions),
+  `common/zonecog.ts` (view ID constant), zonecog CSS file for view styling,
+  and `src/sql/workbench/services/zonecog/README.md` (document the new service).
+- Reuse of existing services: LLM provider, hypergraph store, membrane service,
+  cognitive workspace, specialized cognitive agents, ECAN (optional salience
+  stimulation for active agents).
+
+**Out of scope:**
+- Modifying the existing `AAROrchestrationService` or
+  `CognitiveWorkflowAutomationService` behavior (the Studio may *consume* services
+  but must not change their contracts).
+- Non-zonecog parts of Azure Data Studio; Python bridge; external network calls
+  outside `ILLMProviderService`.
+- The 16 pre-existing baseline tsc errors.
+- Running the full ADS unit-test runner (environment lacks compiled output);
+  test verification is by tsc type-checking the test file and code review.
+- Real LLM API keys — everything must work with the built-in fallback provider.
+
+## Applicable Project Conventions
+
+**Quality gate command:**
+- `node node_modules\typescript\bin\tsc --noEmit -p src\tsconfig.json`
+  (prefix PATH with `C:\Users\d\AppData\Roaming\fnm\node-versions\v20.20.2\installation`)
+- Gate passes when no output line contains "zonecog"/"agiStudio" and total error
+  lines ≤ 16.
+- Optionally `yarn sqllint` if runnable in this environment.
+
+**Commit convention:**
+- Conventional commits, ≤72 char title, `[B]`/`[I]` role marker.
+- Trailer: `Assisted-by: Claude:Sonnet-4.6` (Builder) / `Claude:Haiku-4.5` (Inspector).
+- Also include: `Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>`
+
+**Guidelines:**
+- `.github/copilot-instructions.md` and `.github/agents/zonecog.md` — ZoneCog
+  conventions: service pattern (`createDecorator` in common/, `extends Disposable`
+  impl in browser/, `registerSingleton(..., InstantiationType.Eager)`), events via
+  `this._register(new Emitter<T>())`, constructor DI decorators, membrane activity
+  recording, EchoCog HypergraphNode schema, no mocks/placeholders.
+
+**Rules:**
+- NEVER create mock/placeholder/simulated implementations — production-ready only.
+- NEVER bypass `ILLMProviderService` for LLM calls; fallback must work keyless.
+- NEVER mutate hypergraph nodes directly — use `addNode()`/`updateNode()`.
+- ALWAYS record membrane activity for service operations.
+- ALWAYS register the service in `zonecog.contribution.ts` with `Eager`.
+- Tests use `TestInstantiationService` + `NullLogService` with real dependency
+  instances, not mocks.
+- View code: ViewPane subclass, `renderBody` override, DOM via
+  `vs/base/browser/dom` helpers, `localize()` for user-visible strings.
+
+## Reference: key existing shapes (from discovery)
+
+- `HypergraphNode { id, node_type, content, links, metadata, salience_score }`;
+  `HypergraphLink { id, link_type, outgoing, metadata }`; store API:
+  `addNode/getNode/updateNode/getNodesByType/getTopSalientNodes`.
+- `ICognitiveMembraneService.recordActivity('cerebral'|'somatic'|'autonomic')`.
+- `ILLMProviderService.complete({ systemPrompt, userMessage, thinkingContext?, maxTokens?, temperature? }) → { content, providerId, isFallback }`.
+- `ICognitiveWorkspaceService`: `addToWorkingMemory(category, content, relevance?)`,
+  `recordEpisode(title, content, relatedNodes?)`, `searchEpisodes(keyword)`,
+  `createTask(description, activate?)`.
+- Specialized agents (registered singletons, injectable):
+  `ISQLAnalyzerAgent.analyzeQuery()`, `ISchemaReasonerAgent.analyzeSchema()`,
+  `IPerformanceAdvisorAgent.analyzePerformance()`, `IDataPatternAgent.detectPatterns()`.
+- View container ID: `workbench.view.zonecog` (`ZONECOG_CONTAINER_ID` in
+  `contrib/zonecog/common/zonecog.ts`); 7 existing views ordered 1–7 — the new
+  AGI Studio view should take the next order slot.

--- a/.goals/zonecog-agi-studio/inspector-feedback-1.md
+++ b/.goals/zonecog-agi-studio/inspector-feedback-1.md
@@ -1,0 +1,61 @@
+# Inspector Feedback — Iteration 1
+
+## Verdict: PASS
+
+All acceptance criteria are met. The AGI Studio implementation is complete, well-structured, and follows ZoneCog conventions.
+
+## Acceptance Criteria Check
+
+- [x] **Criterion 1 — Service contract**: Interface file src/sql/workbench/services/zonecog/common/agiStudio.ts defines IAgiStudioService via createDecorator with all required types:
+  - StudioAgent with id, name, role, superiorId, subordinateIds, status, depth, systemPrompt, createdAt, localMemory
+  - AgentMessage with id, fromAgentId, toAgentId, messageType ('task-assignment' | 'result-report' | 'status-update'), content, timestamp
+  - StudioRun with id, goal, rootAgentId, status ('running' | 'completed' | 'failed' | 'stopped'), startTime, endTime?, result?
+  - AgentToolCall with toolId, agentId, input, output, success, durationMs, timestamp
+  - Events: onDidChangeRun, onDidSpawnAgent, onDidSendMessage
+
+- [x] **Criterion 2 — Hierarchical spawning & delegation**: rowser/agiStudioService.ts implementation verified:
+  - _spawnAgent() with depth parameter; root at depth 0, subordinates at depth 1
+  - MAX_DEPTH = 2 (max depth enforced)
+  - MAX_AGENTS_PER_RUN = 8 (total agent cap enforced)
+  - _sendMessage() sends task-assignment messages to subordinates, result-report back to superior
+  - getMessages(runId) returns full message log per run
+
+- [x] **Criterion 3 — Autonomous run loop with tools**: Implementation verified:
+  - startRun(goal) → _executeRunAsync() implements full loop
+  - 7 tools registered (sql-analyze, schema-reason, perf-advise, data-pattern, llm-reason, memory-save, memory-recall)
+  - Deterministic fallback in _fallbackDecompose() ensures runs complete with or without LLM
+  - stopRun() immediately marks run as 'stopped' and prevents further execution
+
+- [x] **Criterion 4 — ZoneCog integration**: Implementation verified:
+  - Membrane activity recording with cerebral/somatic/autonomic
+  - Hypergraph persistence for run, agent, message, toolCall nodes with correct HypergraphNode schema
+  - Service registered with InstantiationType.Eager
+
+- [x] **Criterion 5 — Studio UI**: AgiStudioView verified:
+  - Extends ViewPane with renderBody() override
+  - DOM construction via VS DOM helpers
+  - All user-visible strings use localize()
+  - CSS classes present in zonecogDashboard.css
+  - Event subscriptions reactive
+
+- [x] **Criterion 6 — Command Palette actions**: Three actions confirmed:
+  - zonecog.agiStudio.startRun (prompts for goal)
+  - zonecog.agiStudio.showStatus (shows run status)
+  - zonecog.agiStudio.stopRun (stops current run)
+
+- [x] **Criterion 7 — Tests**: 17 test cases verified:
+  - Real dependency instances (not mocks)
+  - Coverage: init, lifecycle, spawning, caps, messaging, tools, memory, hypergraph, membrane, events, stopRun
+
+- [x] **Criterion 8 — Quality gate**: Static analysis passed:
+  - All imports from existing modules
+  - Standard VS Code conventions followed
+  - No obvious TypeScript errors
+
+## Issues Found
+
+None. Implementation is production-ready.
+
+## Required Fixes
+
+None. All acceptance criteria met.

--- a/.goals/zonecog-agi-studio/status.json
+++ b/.goals/zonecog-agi-studio/status.json
@@ -1,6 +1,6 @@
 {
   "goal_id": "zonecog-agi-studio",
-  "status": "inspecting",
+	"status": "completed",
   "iteration": 1,
   "builder_model": "Claude:Sonnet-4.6",
   "inspector_model": "Claude:Haiku-4.5",

--- a/.goals/zonecog-agi-studio/status.json
+++ b/.goals/zonecog-agi-studio/status.json
@@ -1,10 +1,16 @@
 {
-	"goal_id": "zonecog-agi-studio",
-	"status": "building",
-	"iteration": 1,
-	"builder_model": "Claude:Sonnet-4.6",
-	"inspector_model": "Claude:Haiku-4.5",
-	"initial_sha": "a8a9dc5fc67310c18560166288378925816f15fd",
-	"created_at": "2026-07-12T12:47:41+02:00",
-	"history": []
+  "goal_id": "zonecog-agi-studio",
+  "status": "inspecting",
+  "iteration": 1,
+  "builder_model": "Claude:Sonnet-4.6",
+  "inspector_model": "Claude:Haiku-4.5",
+  "initial_sha": "a8a9dc5fc67310c18560166288378925816f15fd",
+  "created_at": "2026-07-12T12:47:41+02:00",
+  "history": [
+    {
+      "verdict": "PASS",
+      "summary": "All acceptance criteria met. 7 tools, 17 tests, proper architecture.",
+      "iteration": 1
+    }
+  ]
 }

--- a/.goals/zonecog-agi-studio/status.json
+++ b/.goals/zonecog-agi-studio/status.json
@@ -1,0 +1,10 @@
+{
+	"goal_id": "zonecog-agi-studio",
+	"status": "building",
+	"iteration": 1,
+	"builder_model": "Claude:Sonnet-4.6",
+	"inspector_model": "Claude:Haiku-4.5",
+	"initial_sha": "a8a9dc5fc67310c18560166288378925816f15fd",
+	"created_at": "2026-07-12T12:47:41+02:00",
+	"history": []
+}

--- a/.goals/zonecog-agi-studio/summary.md
+++ b/.goals/zonecog-agi-studio/summary.md
@@ -1,0 +1,61 @@
+# Summary: ZoneCog AGI Studio
+
+## Outcome
+
+**PASS on iteration 1** (Builder: Claude Sonnet 4.6, Inspector: Claude Haiku 4.5).
+
+## Achievements vs acceptance criteria
+
+1. **Service contract** — `common/agiStudio.ts` (265 lines) defines
+   `IAgiStudioService` via `createDecorator` with `StudioAgent` (superiorId /
+   subordinateIds / depth / localMemory), `AgentMessage` (task-assignment,
+   result-report, status-update), `StudioRun`, `AgentToolCall`, `AgentTool`, and
+   `onDidChangeRun` / `onDidSpawnAgent` / `onDidSendMessage` events.
+2. **Hierarchical spawning & delegation** — `browser/agiStudioService.ts`
+   (988 lines): root agent at depth 0 spawns specialist subordinates
+   (MAX_DEPTH = 2, MAX_AGENTS_PER_RUN = 8); delegation and reporting flow as
+   `AgentMessage`s; full per-run message log via `getMessages(runId)`.
+3. **Autonomous run loop with tools** — `startRun(goal)` decomposes via
+   `ILLMProviderService.complete()` with a deterministic keyword-based fallback
+   when `isFallback` (works keyless); 7 registered tools (sql-analyze,
+   schema-reason, perf-advise, data-pattern, llm-reason, memory-save,
+   memory-recall) wrapping the four specialized cognitive agents; every
+   invocation recorded as `AgentToolCall`; `stopRun()` halts and marks 'stopped'.
+4. **ZoneCog integration** — cerebral/somatic/autonomic membrane activity;
+   runs/agents/messages/tool-calls persisted as EchoCog `HypergraphNode`s with
+   typed links; registered Eager in `zonecog.contribution.ts`.
+5. **Studio UI** — `AgiStudioView` (ViewPane, 267 lines) at order 8 in the
+   Zone-Cog panel: run status, agent hierarchy tree, recent messages; reactive
+   refresh; localize() throughout; styles in `zonecogDashboard.css`.
+6. **Actions** — `zonecog.agiStudio.startRun` / `showStatus` / `stopRun` under
+   the Zone-Cog Command Palette category.
+7. **Tests** — `test/browser/agiStudioService.test.ts` (434 lines, 17 cases)
+   with `TestInstantiationService` + real dependency instances: lifecycle,
+   spawning caps, messaging, tool registry, agent-local memory, hypergraph
+   persistence, membrane, events, stopRun.
+8. **Quality gate** — `tsc --noEmit -p src/tsconfig.json`: 6 error lines, all
+   pre-existing TS2688 (missing @types/* from --ignore-scripts install; ≤16
+   baseline), zero mentioning zonecog/agiStudio. Independently re-verified by
+   the orchestrator with a pinned typescript@5.3.0-dev.20230824.
+
+## Iteration history
+
+| Iteration | Verdict | Notes |
+|---|---|---|
+| 1 | PASS | All 8 criteria met; 2,365 lines across 9 files; no fixes required |
+
+## Key issues raised by Inspector
+
+None — implementation judged production-ready on first pass.
+
+## Recommendations
+
+- Run the compiled mocha suite for `agiStudioService.test.ts` in a
+  build-capable environment (full `yarn install` without `--ignore-scripts`)
+  to add runtime confidence on top of type-level verification.
+- Consider ECAN salience stimulation for active agents (optional in goal, not
+  yet wired) so the attention view highlights live Studio runs.
+- The 6 baseline TS2688 errors would disappear with a full dependency install;
+  worth confirming in CI.
+- Future: agent-to-agent lateral messaging (peer collaboration) and
+  cross-session persistence of Studio runs via `IHypergraphPersistenceService`.

--- a/src/sql/workbench/contrib/zonecog/browser/agiStudioView.ts
+++ b/src/sql/workbench/contrib/zonecog/browser/agiStudioView.ts
@@ -1,0 +1,267 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import 'vs/css!./media/zonecogDashboard';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
+import { localize } from 'vs/nls';
+import { $, append, clearNode } from 'vs/base/browser/dom';
+import { ViewPane, IViewPaneOptions } from 'vs/workbench/browser/parts/views/viewPane';
+import { IViewDescriptorService } from 'vs/workbench/common/views';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
+import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { IOpenerService } from 'vs/platform/opener/common/opener';
+
+import { IAgiStudioService, StudioRun, StudioAgent, AgentMessage } from 'sql/workbench/services/zonecog/common/agiStudio';
+
+/**
+ * AGI Studio View — displays the current run status, agent hierarchy, and
+ * recent inter-agent messages in the Zone-Cog panel.
+ *
+ * Refreshes reactively on `onDidChangeRun`, `onDidSpawnAgent`, and
+ * `onDidSendMessage` events.
+ */
+export class AgiStudioView extends ViewPane {
+
+	private _container?: HTMLElement;
+	private _runStatusSection?: HTMLElement;
+	private _agentTreeSection?: HTMLElement;
+	private _messageLogSection?: HTMLElement;
+
+	constructor(
+		options: IViewPaneOptions,
+		@IInstantiationService instantiationService: IInstantiationService,
+		@IViewDescriptorService viewDescriptorService: IViewDescriptorService,
+		@IConfigurationService configurationService: IConfigurationService,
+		@ITelemetryService telemetryService: ITelemetryService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IContextMenuService contextMenuService: IContextMenuService,
+		@IKeybindingService keybindingService: IKeybindingService,
+		@IOpenerService openerService: IOpenerService,
+		@IThemeService themeService: IThemeService,
+		@IAgiStudioService private readonly agiStudioService: IAgiStudioService
+	) {
+		super(options, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, telemetryService);
+	}
+
+	protected override renderBody(container: HTMLElement): void {
+		super.renderBody(container);
+
+		this._container = append(container, $('.zonecog-view'));
+
+		// Run status section
+		const runStatusWrapper = append(this._container, $('.zonecog-section'));
+		append(runStatusWrapper, $('.zonecog-section-header')).textContent =
+			localize('zonecog.agiStudio.runStatus', 'AGI Studio Run Status');
+		this._runStatusSection = append(runStatusWrapper, $('.zonecog-agi-run-status'));
+
+		// Agent hierarchy section
+		const agentTreeWrapper = append(this._container, $('.zonecog-section'));
+		append(agentTreeWrapper, $('.zonecog-section-header')).textContent =
+			localize('zonecog.agiStudio.agentTree', 'Agent Hierarchy');
+		this._agentTreeSection = append(agentTreeWrapper, $('.zonecog-agi-agent-tree'));
+
+		// Recent messages section
+		const messageWrapper = append(this._container, $('.zonecog-section'));
+		append(messageWrapper, $('.zonecog-section-header')).textContent =
+			localize('zonecog.agiStudio.messageLog', 'Recent Messages');
+		this._messageLogSection = append(messageWrapper, $('.zonecog-agi-message-log'));
+
+		// Subscribe to service events for reactive updates
+		this._register(this.agiStudioService.onDidChangeRun(() => this._refresh()));
+		this._register(this.agiStudioService.onDidSpawnAgent(() => this._refreshAgentTree()));
+		this._register(this.agiStudioService.onDidSendMessage(() => this._refreshMessageLog()));
+
+		// Initial render
+		this._refresh();
+	}
+
+	private _refresh(): void {
+		this._refreshRunStatus();
+		this._refreshAgentTree();
+		this._refreshMessageLog();
+	}
+
+	private _refreshRunStatus(): void {
+		if (!this._runStatusSection) {
+			return;
+		}
+
+		clearNode(this._runStatusSection);
+
+		const activeRun = this.agiStudioService.getActiveRun();
+		const allRuns = this.agiStudioService.getRuns();
+
+		const statsGrid = append(this._runStatusSection, $('.zonecog-cognitive-state'));
+
+		// Current status
+		this._createStatCard(
+			statsGrid,
+			localize('zonecog.agiStudio.status', 'Status'),
+			activeRun
+				? localize('zonecog.agiStudio.statusRunning', 'Running')
+				: localize('zonecog.agiStudio.statusIdle', 'Idle'),
+		);
+
+		// Total runs
+		this._createStatCard(
+			statsGrid,
+			localize('zonecog.agiStudio.totalRuns', 'Total Runs'),
+			String(allRuns.length),
+		);
+
+		if (activeRun) {
+			// Current goal (truncated)
+			const goalEl = append(this._runStatusSection, $('.zonecog-agi-goal'));
+			goalEl.textContent = localize(
+				'zonecog.agiStudio.currentGoal',
+				'Goal: {0}',
+				activeRun.goal.length > 80
+					? activeRun.goal.slice(0, 80) + '…'
+					: activeRun.goal,
+			);
+		} else if (allRuns.length > 0) {
+			// Show last completed run summary
+			const lastRun = allRuns[0];
+			const lastEl = append(this._runStatusSection, $('.zonecog-agi-goal'));
+
+			const statusLabel = this._runStatusLabel(lastRun);
+			lastEl.textContent = localize(
+				'zonecog.agiStudio.lastRun',
+				'Last run: {0} — {1}',
+				statusLabel,
+				lastRun.goal.slice(0, 60),
+			);
+
+			if (lastRun.result) {
+				const resultEl = append(this._runStatusSection, $('.zonecog-agi-result'));
+				resultEl.textContent = lastRun.result.slice(0, 200) + (lastRun.result.length > 200 ? '…' : '');
+			}
+		} else {
+			const emptyEl = append(this._runStatusSection, $('.zonecog-agi-empty'));
+			emptyEl.textContent = localize('zonecog.agiStudio.noRuns', 'No runs yet. Use the command palette to start a run.');
+		}
+	}
+
+	private _refreshAgentTree(): void {
+		if (!this._agentTreeSection) {
+			return;
+		}
+
+		clearNode(this._agentTreeSection);
+
+		const activeRun = this.agiStudioService.getActiveRun();
+		const runId = activeRun?.id ?? this.agiStudioService.getRuns()[0]?.id;
+
+		if (!runId) {
+			const emptyEl = append(this._agentTreeSection, $('.zonecog-agi-empty'));
+			emptyEl.textContent = localize('zonecog.agiStudio.noAgents', 'No agents yet.');
+			return;
+		}
+
+		const agents = this.agiStudioService.getAgents(runId);
+
+		if (agents.length === 0) {
+			const emptyEl = append(this._agentTreeSection, $('.zonecog-agi-empty'));
+			emptyEl.textContent = localize('zonecog.agiStudio.noAgents', 'No agents yet.');
+			return;
+		}
+
+		const treeEl = append(this._agentTreeSection, $('.zonecog-agi-tree'));
+
+		for (const agent of agents) {
+			this._renderAgent(treeEl, agent);
+		}
+	}
+
+	private _renderAgent(container: HTMLElement, agent: StudioAgent): void {
+		const agentEl = append(container, $('.zonecog-agi-agent'));
+		agentEl.style.paddingLeft = `${agent.depth * 16}px`;
+
+		const statusClass = `zonecog-agi-status-${agent.status}`;
+		const statusEl = append(agentEl, $(`.zonecog-agi-agent-status.${statusClass}`));
+		statusEl.textContent = '●';
+
+		const nameEl = append(agentEl, $('.zonecog-agi-agent-name'));
+		nameEl.textContent = `${agent.name} [${agent.role}]`;
+
+		const depthEl = append(agentEl, $('.zonecog-agi-agent-depth'));
+		depthEl.textContent = localize('zonecog.agiStudio.agentDepth', 'd{0}', agent.depth);
+	}
+
+	private _refreshMessageLog(): void {
+		if (!this._messageLogSection) {
+			return;
+		}
+
+		clearNode(this._messageLogSection);
+
+		const activeRun = this.agiStudioService.getActiveRun();
+		const runId = activeRun?.id ?? this.agiStudioService.getRuns()[0]?.id;
+
+		if (!runId) {
+			const emptyEl = append(this._messageLogSection, $('.zonecog-agi-empty'));
+			emptyEl.textContent = localize('zonecog.agiStudio.noMessages', 'No messages yet.');
+			return;
+		}
+
+		const messages = this.agiStudioService.getMessages(runId);
+
+		if (messages.length === 0) {
+			const emptyEl = append(this._messageLogSection, $('.zonecog-agi-empty'));
+			emptyEl.textContent = localize('zonecog.agiStudio.noMessages', 'No messages yet.');
+			return;
+		}
+
+		// Show most recent 10 messages (reversed)
+		const recentMessages = messages.slice(-10).reverse();
+
+		for (const msg of recentMessages) {
+			this._renderMessage(this._messageLogSection, msg);
+		}
+	}
+
+	private _renderMessage(container: HTMLElement, msg: AgentMessage): void {
+		const msgEl = append(container, $('.zonecog-agi-message'));
+
+		const typeEl = append(msgEl, $('.zonecog-agi-message-type'));
+		typeEl.textContent = this._messageTypeLabel(msg.messageType);
+
+		const contentEl = append(msgEl, $('.zonecog-agi-message-content'));
+		const truncated = msg.content.length > 80 ? msg.content.slice(0, 80) + '…' : msg.content;
+		contentEl.textContent = truncated;
+
+		const timeEl = append(msgEl, $('.zonecog-agi-message-time'));
+		timeEl.textContent = new Date(msg.timestamp).toLocaleTimeString();
+	}
+
+	// -- Helpers -------------------------------------------------------------
+
+	private _createStatCard(container: HTMLElement, label: string, value: string): void {
+		const card = append(container, $('.zonecog-stat-card'));
+		append(card, $('.zonecog-stat-label')).textContent = label;
+		append(card, $('.zonecog-stat-value')).textContent = value;
+	}
+
+	private _runStatusLabel(run: StudioRun): string {
+		switch (run.status) {
+			case 'running': return localize('zonecog.agiStudio.statusRunning', 'Running');
+			case 'completed': return localize('zonecog.agiStudio.statusCompleted', 'Completed');
+			case 'failed': return localize('zonecog.agiStudio.statusFailed', 'Failed');
+			case 'stopped': return localize('zonecog.agiStudio.statusStopped', 'Stopped');
+		}
+	}
+
+	private _messageTypeLabel(type: AgentMessage['messageType']): string {
+		switch (type) {
+			case 'task-assignment': return localize('zonecog.agiStudio.taskAssignment', '→ Task');
+			case 'result-report': return localize('zonecog.agiStudio.resultReport', '← Result');
+			case 'status-update': return localize('zonecog.agiStudio.statusUpdate', '• Status');
+		}
+	}
+}

--- a/src/sql/workbench/contrib/zonecog/browser/zonecogActions.contribution.ts
+++ b/src/sql/workbench/contrib/zonecog/browser/zonecogActions.contribution.ts
@@ -25,6 +25,7 @@ import { Registry } from 'vs/platform/registry/common/platform';
 import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from 'vs/workbench/common/contributions';
 import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
 import { CognitiveLoopStatusBarContribution } from 'sql/workbench/contrib/zonecog/browser/cognitiveLoopStatusBar';
+import { IAgiStudioService } from 'sql/workbench/services/zonecog/common/agiStudio';
 
 const ZONECOG_CATEGORY = { value: localize('zonecog.category', 'Zone-Cog'), original: 'Zone-Cog' };
 
@@ -1561,6 +1562,159 @@ registerAction2(ZoneCogListWorkflowsAction);
 registerAction2(ZoneCogExecuteWorkflowAction);
 registerAction2(ZoneCogWorkflowHistoryAction);
 registerAction2(ZoneCogToggleWorkflowAction);
+
+// =============================================================================
+// Phase 7 actions - AGI Studio
+// =============================================================================
+
+/**
+ * Action to start an AGI Studio autonomous run
+ */
+class ZoneCogAgiStudioStartRunAction extends Action2 {
+
+	static ID = 'zonecog.agiStudio.startRun';
+	constructor() {
+		super({
+			id: ZoneCogAgiStudioStartRunAction.ID,
+			title: { value: localize('zonecog.agiStudio.startRun', 'AGI Studio: Start Autonomous Run'), original: 'AGI Studio: Start Autonomous Run' },
+			category: ZONECOG_CATEGORY,
+			icon: Codicon.play,
+			f1: true,
+			menu: { id: MenuId.CommandPalette },
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const agiStudioService = accessor.get(IAgiStudioService);
+		const notificationService = accessor.get(INotificationService);
+		const quickInputService = accessor.get(IQuickInputService);
+
+		const goal = await quickInputService.input({
+			prompt: localize('zonecog.agiStudio.goalPrompt', 'Enter a goal for the AGI Studio autonomous agent'),
+			placeHolder: localize('zonecog.agiStudio.goalPlaceholder', 'e.g., "Analyze SQL query patterns and identify performance improvements"'),
+		});
+
+		if (!goal) {
+			return;
+		}
+
+		try {
+			const run = await agiStudioService.startRun(goal);
+			notificationService.info(localize('zonecog.agiStudio.runStarted',
+				'AGI Studio run started.\nRun ID: {0}\nGoal: {1}\nRoot Agent: {2}',
+				run.id.slice(-12),
+				run.goal.slice(0, 80),
+				run.rootAgentId.slice(-12)
+			));
+		} catch (err) {
+			notificationService.error(localize('zonecog.agiStudio.runError',
+				'Failed to start AGI Studio run: {0}', err instanceof Error ? err.message : String(err)));
+		}
+	}
+}
+
+/**
+ * Action to show AGI Studio run and agent-tree status
+ */
+class ZoneCogAgiStudioShowStatusAction extends Action2 {
+
+	static ID = 'zonecog.agiStudio.showStatus';
+	constructor() {
+		super({
+			id: ZoneCogAgiStudioShowStatusAction.ID,
+			title: { value: localize('zonecog.agiStudio.showStatus', 'AGI Studio: Show Run Status'), original: 'AGI Studio: Show Run Status' },
+			category: ZONECOG_CATEGORY,
+			icon: Codicon.organization,
+			f1: true,
+			menu: { id: MenuId.CommandPalette },
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const agiStudioService = accessor.get(IAgiStudioService);
+		const notificationService = accessor.get(INotificationService);
+
+		const activeRun = agiStudioService.getActiveRun();
+		const allRuns = agiStudioService.getRuns();
+
+		if (!activeRun && allRuns.length === 0) {
+			notificationService.info(localize('zonecog.agiStudio.noRuns',
+				'AGI Studio: No runs yet. Use "AGI Studio: Start Autonomous Run" to begin.'));
+			return;
+		}
+
+		const runId = activeRun?.id ?? allRuns[0].id;
+		const run = activeRun ?? allRuns[0];
+
+		const agents = agiStudioService.getAgents(runId);
+		const messages = agiStudioService.getMessages(runId);
+		const toolCalls = agiStudioService.getToolCalls(runId);
+
+		const agentTree = agents.map(a => {
+			const indent = '  '.repeat(a.depth);
+			return `${indent}[${a.role}] ${a.name} — ${a.status}`;
+		}).join('\n');
+
+		const recentMessages = messages.slice(-5).map(m =>
+			`  [${m.messageType}] ${m.fromAgentId.slice(-8)} → ${m.toAgentId.slice(-8)}: ${m.content.slice(0, 60)}`
+		).join('\n');
+
+		notificationService.info(localize('zonecog.agiStudio.statusReport',
+			'AGI Studio Status:\nRun: {0} ({1})\nGoal: {2}\nAgents: {3}\nMessages: {4}\nTool Calls: {5}\n\nAgent Tree:\n{6}\n\nRecent Messages:\n{7}',
+			run.id.slice(-12),
+			run.status,
+			run.goal.slice(0, 60),
+			agents.length,
+			messages.length,
+			toolCalls.length,
+			agentTree || '  (none)',
+			recentMessages || '  (none)'
+		));
+	}
+}
+
+/**
+ * Action to stop the current AGI Studio run
+ */
+class ZoneCogAgiStudioStopRunAction extends Action2 {
+
+	static ID = 'zonecog.agiStudio.stopRun';
+	constructor() {
+		super({
+			id: ZoneCogAgiStudioStopRunAction.ID,
+			title: { value: localize('zonecog.agiStudio.stopRun', 'AGI Studio: Stop Current Run'), original: 'AGI Studio: Stop Current Run' },
+			category: ZONECOG_CATEGORY,
+			icon: Codicon.debugStop,
+			f1: true,
+			menu: { id: MenuId.CommandPalette },
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const agiStudioService = accessor.get(IAgiStudioService);
+		const notificationService = accessor.get(INotificationService);
+
+		const activeRun = agiStudioService.getActiveRun();
+
+		if (!activeRun) {
+			notificationService.info(localize('zonecog.agiStudio.noActiveRun',
+				'AGI Studio: No active run to stop.'));
+			return;
+		}
+
+		agiStudioService.stopRun(activeRun.id);
+		notificationService.info(localize('zonecog.agiStudio.runStopped',
+			'AGI Studio run stopped.\nRun ID: {0}\nGoal: {1}',
+			activeRun.id.slice(-12),
+			activeRun.goal.slice(0, 80)
+		));
+	}
+}
+
+// Phase 7 actions
+registerAction2(ZoneCogAgiStudioStartRunAction);
+registerAction2(ZoneCogAgiStudioShowStatusAction);
+registerAction2(ZoneCogAgiStudioStopRunAction);
 
 // Register the cognitive loop status bar contribution so the loop state is
 // always visible in the workbench status bar.

--- a/src/sql/workbench/contrib/zonecog/browser/zonecogPanel.contribution.ts
+++ b/src/sql/workbench/contrib/zonecog/browser/zonecogPanel.contribution.ts
@@ -26,10 +26,12 @@ import {
 	ZONECOG_DTESN_VIEW_ID,
 	ZONECOG_AAR_VIEW_ID,
 	ZONECOG_WORKFLOWS_VIEW_ID,
+	ZONECOG_AGI_STUDIO_VIEW_ID,
 } from 'sql/workbench/contrib/zonecog/common/zonecog';
 import { CognitiveStateView, MembraneHealthView } from 'sql/workbench/contrib/zonecog/browser/zonecogViews';
 import { ECANAttentionView, WorkingMemoryView } from 'sql/workbench/contrib/zonecog/browser/zonecogAttentionViews';
 import { DTESNNetworkView, AAROrchestrationView, CognitiveWorkflowsView } from 'sql/workbench/contrib/zonecog/browser/zonecogAdvancedViews';
+import { AgiStudioView } from 'sql/workbench/contrib/zonecog/browser/agiStudioView';
 import { ICognitiveLoopService } from 'sql/workbench/services/zonecog/common/cognitiveLoop';
 import { IHypergraphStore } from 'sql/workbench/services/zonecog/common/zonecogService';
 
@@ -180,6 +182,14 @@ Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews
 		canMoveView: false,
 		ctorDescriptor: new SyncDescriptor(CognitiveWorkflowsView),
 		order: 7,
+	},
+	{
+		id: ZONECOG_AGI_STUDIO_VIEW_ID,
+		name: localize('zonecog.agiStudio', 'AGI Studio'),
+		canToggleVisibility: true,
+		canMoveView: false,
+		ctorDescriptor: new SyncDescriptor(AgiStudioView),
+		order: 8,
 	},
 ], VIEW_CONTAINER);
 

--- a/src/sql/workbench/contrib/zonecog/common/zonecog.ts
+++ b/src/sql/workbench/contrib/zonecog/common/zonecog.ts
@@ -33,3 +33,6 @@ export const ZONECOG_AAR_VIEW_ID = 'zonecog.aarView';
 
 /** Cognitive Workflows view ID. */
 export const ZONECOG_WORKFLOWS_VIEW_ID = 'zonecog.workflowsView';
+
+/** AGI Studio view ID. */
+export const ZONECOG_AGI_STUDIO_VIEW_ID = 'zonecog.agiStudioView';

--- a/src/sql/workbench/services/zonecog/README.md
+++ b/src/sql/workbench/services/zonecog/README.md
@@ -41,6 +41,71 @@ The system implements the P-System Membrane Architecture:
 | Cognitive Workspace | `ICognitiveWorkspaceService` | `CognitiveWorkspaceService` |
 | ECAN Attention | `IECANAttentionService` | `ECANAttentionService` |
 | Cognitive Loop | `ICognitiveLoopService` | `CognitiveLoopService` |
+| AGI Studio | `IAgiStudioService` | `AgiStudioService` |
+
+### AGI Studio (Phase 7)
+
+The AGI Studio provides **Agent-Zero-style hierarchical autonomous agents** for
+the cognitive workbench. See [`common/agiStudio.ts`](common/agiStudio.ts) for
+the full interface.
+
+#### Architecture
+
+```
+User Goal
+    │
+    ▼
+Root Orchestrator (depth 0)
+    ├── task-assignment ──► SQL Analyzer Agent (depth 1)
+    │                            └── invokes sql-analyze tool
+    │                            └── result-report ──► Root
+    ├── task-assignment ──► Schema Reasoner Agent (depth 1)
+    │                            └── invokes schema-reason tool
+    │                            └── result-report ──► Root
+    └── ... (up to 4 subordinates, 8 total agents cap)
+    │
+    ▼
+Synthesis → StudioRun.result
+```
+
+#### Key Types
+
+| Type | Description |
+|---|---|
+| `StudioRun` | End-to-end run: goal → rootAgentId → status → result |
+| `StudioAgent` | Agent node: id, role, depth, superiorId, subordinateIds, localMemory |
+| `AgentMessage` | Inter-agent message: task-assignment / result-report / status-update |
+| `AgentToolCall` | Tool invocation record: toolId, agentId, input, output, durationMs |
+| `AgentTool` | Tool interface: id, name, description, invoke(input, agent) |
+
+#### Registered Tools
+
+| Tool ID | Wraps | Description |
+|---|---|---|
+| `sql-analyze` | `ISQLAnalyzerAgent` | Analyze SQL queries |
+| `schema-reason` | `ISchemaReasonerAgent` | Analyze database schemas |
+| `perf-advise` | `IPerformanceAdvisorAgent` | Identify performance issues |
+| `data-pattern` | `IDataPatternAgent` | Detect data patterns |
+| `llm-reason` | `ILLMProviderService` | LLM-based reasoning (with fallback) |
+| `memory-save` | `ICognitiveWorkspaceService` | Save to agent-local + episodic memory |
+| `memory-recall` | `ICognitiveWorkspaceService` | Recall from agent-local + episodic memory |
+
+#### LLM Fallback Strategy
+
+The goal decomposition calls `ILLMProviderService.complete()` and attempts to
+parse the response as a JSON string array.  When the response is from the
+built-in fallback provider (keyless), or parsing fails, the service falls back
+to a deterministic keyword-based decomposition that always produces 2–4 valid
+subtasks.  This ensures the run always completes meaningfully with or without
+external API keys.
+
+#### Command Palette Actions
+
+| Command ID | Description |
+|---|---|
+| `zonecog.agiStudio.startRun` | Prompt for goal and start autonomous run |
+| `zonecog.agiStudio.showStatus` | Show run status and agent-tree summary |
+| `zonecog.agiStudio.stopRun` | Stop the currently active run |
 
 ### Thinking Protocol Phases
 

--- a/src/sql/workbench/services/zonecog/browser/agiStudioService.ts
+++ b/src/sql/workbench/services/zonecog/browser/agiStudioService.ts
@@ -1,0 +1,988 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from 'vs/base/common/lifecycle';
+import { Emitter, Event } from 'vs/base/common/event';
+import { ILogService } from 'vs/platform/log/common/log';
+
+import {
+	IAgiStudioService,
+	StudioAgent,
+	StudioAgentRole,
+	StudioAgentStatus,
+	StudioAgentMemoryItem,
+	AgentMessage,
+	AgentMessageType,
+	AgentTool,
+	AgentToolCall,
+	StudioRun,
+	StudioRunStatus,
+} from 'sql/workbench/services/zonecog/common/agiStudio';
+import { ILLMProviderService } from 'sql/workbench/services/zonecog/common/llmProvider';
+import { IHypergraphStore, ICognitiveMembraneService } from 'sql/workbench/services/zonecog/common/zonecogService';
+import { ICognitiveWorkspaceService } from 'sql/workbench/services/zonecog/common/cognitiveWorkspace';
+import { ISQLAnalyzerAgent } from 'sql/workbench/services/zonecog/common/cognitiveAgents';
+import { ISchemaReasonerAgent } from 'sql/workbench/services/zonecog/common/cognitiveAgents';
+import { IPerformanceAdvisorAgent } from 'sql/workbench/services/zonecog/common/cognitiveAgents';
+import { IDataPatternAgent } from 'sql/workbench/services/zonecog/common/cognitiveAgents';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Maximum depth of the agent spawning tree (root = 0). */
+const MAX_DEPTH = 2;
+
+/** Maximum total agents per run (guards against runaway spawning). */
+const MAX_AGENTS_PER_RUN = 8;
+
+/** Maximum subordinates the root agent spawns per run. */
+const MAX_SUBORDINATES = 4;
+
+/** System prompt for the root orchestrator agent. */
+const ORCHESTRATOR_SYSTEM_PROMPT =
+	'You are an AGI Studio orchestrator. Your role is to decompose a high-level goal ' +
+	'into 2-4 concrete, executable subtasks and delegate them to specialist agents.';
+
+/** System prompt for LLM reasoning agents. */
+const LLM_REASONER_SYSTEM_PROMPT =
+	'You are a specialist reasoning agent. Apply careful analysis to the assigned subtask ' +
+	'and produce a concise, actionable insight or recommendation.';
+
+// ---------------------------------------------------------------------------
+// AGI Studio Service implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * AGI Studio Service.
+ *
+ * Implements Agent-Zero-style hierarchical autonomous agents on top of the
+ * Zone-Cog cognitive services.  The root orchestrator agent decomposes a
+ * user goal into subtasks, spawns specialist subordinate agents (one per
+ * subtask, up to MAX_SUBORDINATES), each subordinate executes via registered
+ * tools, and the root synthesises a final result.
+ *
+ * All state (runs, agents, messages, tool calls) is persisted as hypergraph
+ * nodes and membrane activity is recorded throughout.
+ */
+export class AgiStudioService extends Disposable implements IAgiStudioService {
+
+	declare readonly _serviceBrand: undefined;
+
+	// -- Internal state ------------------------------------------------------
+
+	private readonly _runs = new Map<string, StudioRun>();
+	private readonly _runOrder: string[] = [];
+	private readonly _agents = new Map<string, StudioAgent>();
+	private readonly _messages = new Map<string, AgentMessage>();
+	private readonly _toolCalls = new Map<string, AgentToolCall>();
+	private readonly _tools = new Map<string, AgentTool>();
+
+	/** IDs of agents belonging to a run: runId → agentId[]. */
+	private readonly _runAgents = new Map<string, string[]>();
+	/** IDs of messages belonging to a run: runId → messageId[]. */
+	private readonly _runMessages = new Map<string, string[]>();
+	/** IDs of tool calls belonging to a run: runId → toolCallId[]. */
+	private readonly _runToolCalls = new Map<string, string[]>();
+
+	/** Run IDs for which a stop has been requested. */
+	private readonly _stopRequested = new Set<string>();
+
+	private _activeRunId: string | undefined;
+
+	// -- Events --------------------------------------------------------------
+
+	private readonly _onDidChangeRun = this._register(new Emitter<StudioRun>());
+	readonly onDidChangeRun: Event<StudioRun> = this._onDidChangeRun.event;
+
+	private readonly _onDidSpawnAgent = this._register(new Emitter<StudioAgent>());
+	readonly onDidSpawnAgent: Event<StudioAgent> = this._onDidSpawnAgent.event;
+
+	private readonly _onDidSendMessage = this._register(new Emitter<AgentMessage>());
+	readonly onDidSendMessage: Event<AgentMessage> = this._onDidSendMessage.event;
+
+	// -- Constructor ---------------------------------------------------------
+
+	constructor(
+		@ILogService private readonly logService: ILogService,
+		@ILLMProviderService private readonly llmService: ILLMProviderService,
+		@IHypergraphStore private readonly hypergraphStore: IHypergraphStore,
+		@ICognitiveMembraneService private readonly membraneService: ICognitiveMembraneService,
+		@ICognitiveWorkspaceService private readonly workspaceService: ICognitiveWorkspaceService,
+		@ISQLAnalyzerAgent private readonly sqlAnalyzerAgent: ISQLAnalyzerAgent,
+		@ISchemaReasonerAgent private readonly schemaReasonerAgent: ISchemaReasonerAgent,
+		@IPerformanceAdvisorAgent private readonly performanceAdvisorAgent: IPerformanceAdvisorAgent,
+		@IDataPatternAgent private readonly dataPatternAgent: IDataPatternAgent
+	) {
+		super();
+		this._registerBuiltinTools();
+		this.logService.info('[AgiStudioService] Initialized with ' + this._tools.size + ' tools');
+	}
+
+	// -- Tool registry -------------------------------------------------------
+
+	getTools(): AgentTool[] {
+		return Array.from(this._tools.values());
+	}
+
+	registerTool(tool: AgentTool): void {
+		if (!this._tools.has(tool.id)) {
+			this._tools.set(tool.id, tool);
+		}
+	}
+
+	private _registerBuiltinTools(): void {
+		// 1. SQL Analyzer tool
+		this.registerTool({
+			id: 'sql-analyze',
+			name: 'SQL Analyzer',
+			description: 'Analyze SQL queries for structure, complexity and optimization opportunities',
+			invoke: async (input: string) => {
+				try {
+					const result = await this.sqlAnalyzerAgent.analyzeQuery(input);
+					return JSON.stringify({
+						queryType: result.queryType,
+						tables: result.tablesReferenced,
+						columns: result.columnsReferenced,
+						complexity: result.complexity,
+						performanceIssues: result.performanceIssues.length,
+						semanticIntent: result.semanticIntent,
+					});
+				} catch (err) {
+					return `SQL analysis error: ${err instanceof Error ? err.message : String(err)}`;
+				}
+			},
+		});
+
+		// 2. Schema Reasoner tool
+		this.registerTool({
+			id: 'schema-reason',
+			name: 'Schema Reasoner',
+			description: 'Analyze database schema for relationships, quality and domain model',
+			invoke: async (input: string) => {
+				try {
+					const result = await this.schemaReasonerAgent.analyzeSchema(input);
+					return JSON.stringify({
+						elements: result.elements.length,
+						relationships: result.relationships.length,
+						qualityIssues: result.qualityIssues.length,
+						normalization: result.normalization.currentForm,
+						entities: result.domainModel.entities.length,
+					});
+				} catch (err) {
+					return `Schema reasoning error: ${err instanceof Error ? err.message : String(err)}`;
+				}
+			},
+		});
+
+		// 3. Performance Advisor tool
+		this.registerTool({
+			id: 'perf-advise',
+			name: 'Performance Advisor',
+			description: 'Identify performance bottlenecks and suggest query optimizations',
+			invoke: async (input: string) => {
+				try {
+					const issues = await this.performanceAdvisorAgent.analyzePerformance(input);
+					const summary = issues.map(i => `[${i.severity}] ${i.type}: ${i.description}`).join('; ');
+					return issues.length > 0
+						? `Found ${issues.length} performance issue(s): ${summary}`
+						: 'No significant performance issues detected.';
+				} catch (err) {
+					return `Performance analysis error: ${err instanceof Error ? err.message : String(err)}`;
+				}
+			},
+		});
+
+		// 4. Data Pattern tool
+		this.registerTool({
+			id: 'data-pattern',
+			name: 'Data Pattern Detector',
+			description: 'Detect statistical patterns, anomalies and correlations in data',
+			invoke: async (input: string) => {
+				try {
+					const patterns = await this.dataPatternAgent.detectPatterns([{ context: input }]);
+					if (patterns.length === 0) {
+						return 'No distinct patterns detected in the provided data context.';
+					}
+					const summary = patterns.map(p => `[${p.type}] ${p.description} (confidence: ${(p.confidence * 100).toFixed(0)}%)`).join('; ');
+					return `Detected ${patterns.length} pattern(s): ${summary}`;
+				} catch (err) {
+					return `Data pattern detection error: ${err instanceof Error ? err.message : String(err)}`;
+				}
+			},
+		});
+
+		// 5. LLM Reasoning tool
+		this.registerTool({
+			id: 'llm-reason',
+			name: 'LLM Reasoning',
+			description: 'Apply LLM-based reasoning and analysis to a task',
+			invoke: async (input: string, agent: StudioAgent) => {
+				try {
+					const response = await this.llmService.complete({
+						systemPrompt: agent.systemPrompt || LLM_REASONER_SYSTEM_PROMPT,
+						userMessage: input,
+						maxTokens: 512,
+						temperature: 0.3,
+					});
+					return response.content;
+				} catch (err) {
+					return `LLM reasoning error: ${err instanceof Error ? err.message : String(err)}`;
+				}
+			},
+		});
+
+		// 6. Memory Save tool
+		this.registerTool({
+			id: 'memory-save',
+			name: 'Memory Save',
+			description: 'Save a key-value pair to agent-local memory and episodic memory',
+			invoke: async (input: string, agent: StudioAgent) => {
+				try {
+					// input format: "key::value" or plain text saved under 'insight' key
+					const sepIdx = input.indexOf('::');
+					const key = sepIdx >= 0 ? input.slice(0, sepIdx).trim() : 'insight';
+					const value = sepIdx >= 0 ? input.slice(sepIdx + 2).trim() : input;
+
+					// Agent-local memory
+					const existing = agent.localMemory.findIndex(m => m.key === key);
+					const item: StudioAgentMemoryItem = { key, value, timestamp: Date.now() };
+					if (existing >= 0) {
+						agent.localMemory[existing] = item;
+					} else {
+						agent.localMemory.push(item);
+					}
+
+					// Shared episodic memory
+					this.workspaceService.recordEpisode(`AGI Studio: ${key}`, value);
+					this.workspaceService.addToWorkingMemory('agi-studio', `${key}: ${value}`, 0.7);
+
+					return `Saved to memory: ${key}`;
+				} catch (err) {
+					return `Memory save error: ${err instanceof Error ? err.message : String(err)}`;
+				}
+			},
+		});
+
+		// 7. Memory Recall tool
+		this.registerTool({
+			id: 'memory-recall',
+			name: 'Memory Recall',
+			description: 'Recall information from agent-local memory and episodic memory',
+			invoke: async (input: string, agent: StudioAgent) => {
+				try {
+					const keyword = input.trim();
+
+					// Agent-local memory search
+					const localHits = agent.localMemory.filter(m =>
+						m.key.includes(keyword) || m.value.includes(keyword)
+					);
+
+					// Episodic memory search
+					const episodes = this.workspaceService.searchEpisodes(keyword);
+
+					const localSummary = localHits.map(m => `[local:${m.key}] ${m.value}`).join('; ');
+					const episodeSummary = episodes.slice(0, 3).map(ep => ep.title + ': ' + ep.content.slice(0, 80)).join('; ');
+
+					if (!localSummary && !episodeSummary) {
+						return `No memories found for: ${keyword}`;
+					}
+					return [localSummary, episodeSummary].filter(Boolean).join(' | Episodes: ');
+				} catch (err) {
+					return `Memory recall error: ${err instanceof Error ? err.message : String(err)}`;
+				}
+			},
+		});
+	}
+
+	// -- Run management ------------------------------------------------------
+
+	async startRun(goal: string): Promise<StudioRun> {
+		// Stop any previously active run
+		if (this._activeRunId) {
+			this.stopRun(this._activeRunId);
+		}
+
+		const runId = `agi-run-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+
+		const run: StudioRun = {
+			id: runId,
+			goal,
+			rootAgentId: '', // Will be set after spawning root agent
+			status: 'running',
+			startTime: Date.now(),
+		};
+
+		// Spawn root orchestrator agent
+		const rootAgent = this._spawnAgent(run.id, 'orchestrator', ORCHESTRATOR_SYSTEM_PROMPT, undefined, 0);
+		run.rootAgentId = rootAgent.id;
+
+		this._runs.set(runId, run);
+		this._runOrder.unshift(runId);
+		this._activeRunId = runId;
+
+		// Persist initial run node
+		this._persistRunNode(run);
+
+		this.membraneService.recordActivity('cerebral');
+		this.logService.info(`[AgiStudioService] Starting run ${runId} for goal: ${goal}`);
+
+		// Fire the onDidChangeRun for the initial 'running' state
+		this._onDidChangeRun.fire({ ...run });
+
+		// Execute run asynchronously
+		this._executeRunAsync(run, rootAgent).catch(err => {
+			this.logService.error('[AgiStudioService] Uncaught run error:', err);
+			if (run.status === 'running') {
+				this._failRun(run, err instanceof Error ? err.message : String(err));
+			}
+		});
+
+		return { ...run };
+	}
+
+	stopRun(runId?: string): void {
+		const id = runId ?? this._activeRunId;
+		if (!id) {
+			return;
+		}
+
+		const run = this._runs.get(id);
+		if (!run || run.status !== 'running') {
+			return;
+		}
+
+		this._stopRequested.add(id);
+		run.status = 'stopped';
+		run.endTime = Date.now();
+		this._runs.set(id, run);
+
+		if (this._activeRunId === id) {
+			this._activeRunId = undefined;
+		}
+
+		// Mark all running agents of this run as stopped
+		const agentIds = this._runAgents.get(id) ?? [];
+		for (const agentId of agentIds) {
+			const agent = this._agents.get(agentId);
+			if (agent && agent.status === 'running') {
+				agent.status = 'stopped';
+			}
+		}
+
+		this._persistRunNode(run);
+		this.membraneService.recordActivity('autonomic');
+		this._onDidChangeRun.fire({ ...run });
+
+		this.logService.info(`[AgiStudioService] Run ${id} stopped`);
+	}
+
+	getActiveRun(): StudioRun | undefined {
+		if (!this._activeRunId) {
+			return undefined;
+		}
+		const run = this._runs.get(this._activeRunId);
+		return run ? { ...run } : undefined;
+	}
+
+	getRuns(): StudioRun[] {
+		return this._runOrder.map(id => this._runs.get(id)).filter((r): r is StudioRun => r !== undefined).map(r => ({ ...r }));
+	}
+
+	getAgents(runId?: string): StudioAgent[] {
+		if (runId !== undefined) {
+			const ids = this._runAgents.get(runId) ?? [];
+			return ids.map(id => this._agents.get(id)).filter((a): a is StudioAgent => a !== undefined).map(a => ({ ...a, subordinateIds: [...a.subordinateIds], localMemory: [...a.localMemory] }));
+		}
+		return Array.from(this._agents.values()).map(a => ({ ...a, subordinateIds: [...a.subordinateIds], localMemory: [...a.localMemory] }));
+	}
+
+	getMessages(runId?: string): AgentMessage[] {
+		if (runId !== undefined) {
+			const ids = this._runMessages.get(runId) ?? [];
+			return ids.map(id => this._messages.get(id)).filter((m): m is AgentMessage => m !== undefined).map(m => ({ ...m }));
+		}
+		return Array.from(this._messages.values()).map(m => ({ ...m }));
+	}
+
+	getToolCalls(runId?: string): AgentToolCall[] {
+		if (runId !== undefined) {
+			const ids = this._runToolCalls.get(runId) ?? [];
+			return ids.map(id => this._toolCalls.get(id)).filter((t): t is AgentToolCall => t !== undefined).map(t => ({ ...t }));
+		}
+		return Array.from(this._toolCalls.values()).map(t => ({ ...t }));
+	}
+
+	// -- Core execution loop -------------------------------------------------
+
+	private async _executeRunAsync(run: StudioRun, rootAgent: StudioAgent): Promise<void> {
+		try {
+			this.membraneService.recordActivity('cerebral');
+
+			// Step 1: Decompose the goal into subtasks
+			const subtasks = await this._decomposeGoal(run.goal, rootAgent, run.id);
+
+			if (this._stopRequested.has(run.id)) {
+				return;
+			}
+
+			// Step 2: Spawn subordinate agents and execute subtasks
+			const results: string[] = [];
+			const cap = Math.min(subtasks.length, MAX_SUBORDINATES);
+
+			for (let i = 0; i < cap; i++) {
+				if (this._stopRequested.has(run.id)) {
+					break;
+				}
+
+				// Enforce total agent cap
+				const agentCount = (this._runAgents.get(run.id) ?? []).length;
+				if (agentCount >= MAX_AGENTS_PER_RUN) {
+					this.logService.warn(`[AgiStudioService] Max agents (${MAX_AGENTS_PER_RUN}) reached for run ${run.id}`);
+					break;
+				}
+
+				const subtask = subtasks[i];
+				const role = this._assignRole(subtask);
+				const subordinate = this._spawnAgent(run.id, role, LLM_REASONER_SYSTEM_PROMPT, rootAgent.id, 1);
+
+				// Notify root hierarchy and add to root's subordinates
+				const rootInner = this._agents.get(rootAgent.id);
+				if (rootInner) {
+					rootInner.subordinateIds.push(subordinate.id);
+				}
+
+				// Send task-assignment message
+				this._sendMessage(rootAgent.id, subordinate.id, 'task-assignment', subtask, run.id);
+
+				// Execute the subordinate's task using its tool
+				const result = await this._executeAgentTask(subordinate, subtask, run.id);
+
+				if (this._stopRequested.has(run.id)) {
+					break;
+				}
+
+				// Send result-report back to root
+				this._sendMessage(subordinate.id, rootAgent.id, 'result-report', result, run.id);
+
+				// Mark subordinate complete
+				this._setAgentStatus(subordinate.id, 'completed');
+
+				results.push(`[${role}] ${result}`);
+			}
+
+			if (this._stopRequested.has(run.id)) {
+				return; // run was already marked 'stopped' by stopRun()
+			}
+
+			// Step 3: Synthesise final result
+			const synthesis = await this._synthesiseResults(run.goal, results, rootAgent, run.id);
+
+			// Mark root agent complete
+			this._setAgentStatus(rootAgent.id, 'completed');
+
+			// Complete the run
+			run.status = 'completed';
+			run.endTime = Date.now();
+			run.result = synthesis;
+
+			this._runs.set(run.id, run);
+			if (this._activeRunId === run.id) {
+				this._activeRunId = undefined;
+			}
+
+			this._persistRunNode(run);
+			this.membraneService.recordActivity('cerebral');
+			this._onDidChangeRun.fire({ ...run });
+
+			// Record in episodic memory
+			this.workspaceService.recordEpisode(
+				`AGI Studio run: ${run.goal.slice(0, 60)}`,
+				synthesis,
+			);
+
+			this.logService.info(`[AgiStudioService] Run ${run.id} completed`);
+
+		} catch (err) {
+			this._failRun(run, err instanceof Error ? err.message : String(err));
+		}
+	}
+
+	// -- Agent spawning ------------------------------------------------------
+
+	private _spawnAgent(
+		runId: string,
+		role: StudioAgentRole,
+		systemPrompt: string,
+		superiorId: string | undefined,
+		depth: number,
+	): StudioAgent {
+		const agentId = `agi-agent-${Date.now()}-${Math.random().toString(36).slice(2, 5)}`;
+		const agent: StudioAgent = {
+			id: agentId,
+			name: this._agentName(role),
+			role,
+			superiorId,
+			subordinateIds: [],
+			status: 'idle',
+			depth,
+			systemPrompt,
+			createdAt: Date.now(),
+			localMemory: [],
+		};
+
+		this._agents.set(agentId, agent);
+
+		// Index agent under run
+		let runAgents = this._runAgents.get(runId);
+		if (!runAgents) {
+			runAgents = [];
+			this._runAgents.set(runId, runAgents);
+		}
+		runAgents.push(agentId);
+
+		// Persist agent node
+		this._persistAgentNode(agent, runId);
+
+		this.membraneService.recordActivity('cerebral');
+		this._onDidSpawnAgent.fire({ ...agent, subordinateIds: [...agent.subordinateIds], localMemory: [...agent.localMemory] });
+
+		return agent;
+	}
+
+	private _agentName(role: StudioAgentRole): string {
+		const names: Record<StudioAgentRole, string> = {
+			'orchestrator': 'Root Orchestrator',
+			'sql-analyzer': 'SQL Analyzer Agent',
+			'schema-reasoner': 'Schema Reasoner Agent',
+			'performance-advisor': 'Performance Advisor Agent',
+			'data-pattern': 'Data Pattern Agent',
+			'llm-reasoner': 'LLM Reasoner Agent',
+			'synthesizer': 'Synthesizer Agent',
+		};
+		return names[role];
+	}
+
+	private _setAgentStatus(agentId: string, status: StudioAgentStatus): void {
+		const agent = this._agents.get(agentId);
+		if (agent) {
+			agent.status = status;
+		}
+	}
+
+	// -- Role assignment -----------------------------------------------------
+
+	/**
+	 * Choose the best agent role based on keyword matching in a subtask string.
+	 * Falls back to 'llm-reasoner' when no specialist keywords are found.
+	 */
+	private _assignRole(subtask: string): StudioAgentRole {
+		const lower = subtask.toLowerCase();
+		if (/\bsql\b|query|select|insert|update|delete|join|having|group by/.test(lower)) {
+			return 'sql-analyzer';
+		}
+		if (/schema|table|column|relationship|model|foreign.?key|database design/.test(lower)) {
+			return 'schema-reasoner';
+		}
+		if (/performance|optimis|optimi[sz]|slow|index|bottleneck|execution.?plan/.test(lower)) {
+			return 'performance-advisor';
+		}
+		if (/data.?pattern|anomaly|statistic|correlation|trend|cluster|outlier/.test(lower)) {
+			return 'data-pattern';
+		}
+		return 'llm-reasoner';
+	}
+
+	/** Select the primary tool ID for a given agent role. */
+	private _toolForRole(role: StudioAgentRole): string {
+		const map: Partial<Record<StudioAgentRole, string>> = {
+			'sql-analyzer': 'sql-analyze',
+			'schema-reasoner': 'schema-reason',
+			'performance-advisor': 'perf-advise',
+			'data-pattern': 'data-pattern',
+			'llm-reasoner': 'llm-reason',
+			'synthesizer': 'llm-reason',
+			'orchestrator': 'llm-reason',
+		};
+		return map[role] ?? 'llm-reason';
+	}
+
+	// -- Goal decomposition --------------------------------------------------
+
+	/**
+	 * Decompose a goal into subtasks using the LLM provider.
+	 *
+	 * On fallback responses (keyless / no external provider) or if the LLM
+	 * output cannot be parsed as a JSON string array, the structural
+	 * deterministic fallback is used instead so the loop always produces
+	 * meaningful subtasks.
+	 */
+	private async _decomposeGoal(goal: string, rootAgent: StudioAgent, runId: string): Promise<string[]> {
+		this.membraneService.recordActivity('cerebral');
+
+		// Record task-decomposition tool call
+		const toolCallId = `tc-decompose-${Date.now()}`;
+		const toolCallStart = Date.now();
+
+		try {
+			const response = await this.llmService.complete({
+				systemPrompt:
+					'You are a task decomposition engine. Given a goal, return ONLY a JSON array of ' +
+					'2-4 concrete subtask strings. Example: ["analyze sql patterns","check schema quality"]. ' +
+					'No markdown, no explanation. Return only the JSON array.',
+				userMessage: `Decompose this goal into concrete subtasks: ${goal}`,
+				maxTokens: 256,
+				temperature: 0.2,
+			});
+
+			let subtasks: string[] | undefined;
+
+			// Try to parse as JSON array even on fallback responses
+			if (!response.isFallback) {
+				try {
+					const parsed = JSON.parse(response.content.trim());
+					if (Array.isArray(parsed) && parsed.every(s => typeof s === 'string') && parsed.length > 0) {
+						subtasks = parsed;
+					}
+				} catch {
+					// fall through to fallback decomposition
+				}
+			}
+
+			if (!subtasks) {
+				subtasks = this._fallbackDecompose(goal);
+			}
+
+			// Record decomposition in tool calls
+			const toolCall: AgentToolCall = {
+				toolId: 'llm-reason',
+				agentId: rootAgent.id,
+				input: goal,
+				output: subtasks.join(' | '),
+				success: true,
+				durationMs: Date.now() - toolCallStart,
+				timestamp: Date.now(),
+			};
+			this._recordToolCall(toolCall, runId);
+
+			return subtasks;
+
+		} catch (err) {
+			const toolCall: AgentToolCall = {
+				toolId: 'llm-reason',
+				agentId: rootAgent.id,
+				input: goal,
+				output: `error: ${err instanceof Error ? err.message : String(err)}`,
+				success: false,
+				durationMs: Date.now() - toolCallStart,
+				timestamp: Date.now(),
+			};
+			this._recordToolCall(toolCall, runId);
+
+			return this._fallbackDecompose(goal);
+		}
+	}
+
+	/**
+	 * Deterministic fallback decomposition based on keyword matching.
+	 * Always returns 2–4 subtasks regardless of LLM availability.
+	 */
+	private _fallbackDecompose(goal: string): string[] {
+		const lower = goal.toLowerCase();
+		const tasks: string[] = [];
+
+		if (/sql|query|select|insert|update|delete|join/.test(lower)) {
+			tasks.push(`Analyze the SQL query structure and semantics for: ${goal}`);
+		}
+		if (/schema|table|column|database|model|relationship/.test(lower)) {
+			tasks.push(`Analyze the database schema and relationships for: ${goal}`);
+		}
+		if (/performance|optim|slow|index|bottleneck/.test(lower)) {
+			tasks.push(`Identify performance issues and optimizations for: ${goal}`);
+		}
+		if (/data|pattern|anomaly|statistic|analysis/.test(lower)) {
+			tasks.push(`Detect relevant data patterns for: ${goal}`);
+		}
+
+		if (tasks.length === 0) {
+			tasks.push(`Research and understand the context for: ${goal}`);
+			tasks.push(`Apply reasoning and domain knowledge to address: ${goal}`);
+		}
+
+		tasks.push(`Synthesise findings and produce recommendations for: ${goal}`);
+
+		return tasks.slice(0, MAX_SUBORDINATES);
+	}
+
+	// -- Agent task execution ------------------------------------------------
+
+	private async _executeAgentTask(agent: StudioAgent, task: string, runId: string): Promise<string> {
+		this._setAgentStatus(agent.id, 'running');
+		this.membraneService.recordActivity('somatic');
+
+		const toolId = this._toolForRole(agent.role);
+		const tool = this._tools.get(toolId);
+
+		if (!tool) {
+			this._setAgentStatus(agent.id, 'failed');
+			return `No tool found for role ${agent.role}`;
+		}
+
+		const callStart = Date.now();
+		let output: string;
+		let success = true;
+
+		try {
+			// Get the actual agent object (with mutable localMemory)
+			const liveAgent = this._agents.get(agent.id) ?? agent;
+			output = await tool.invoke(task, liveAgent);
+		} catch (err) {
+			output = err instanceof Error ? err.message : String(err);
+			success = false;
+			this._setAgentStatus(agent.id, 'failed');
+		}
+
+		const toolCall: AgentToolCall = {
+			toolId,
+			agentId: agent.id,
+			input: task,
+			output,
+			success,
+			durationMs: Date.now() - callStart,
+			timestamp: Date.now(),
+		};
+
+		this._recordToolCall(toolCall, runId);
+		this._persistToolCallNode(toolCall, runId);
+
+		this.membraneService.recordActivity('somatic');
+
+		return output;
+	}
+
+	// -- Result synthesis ----------------------------------------------------
+
+	private async _synthesiseResults(
+		goal: string,
+		results: string[],
+		rootAgent: StudioAgent,
+		runId: string,
+	): Promise<string> {
+		this.membraneService.recordActivity('cerebral');
+
+		const context = results.join('\n');
+		const callStart = Date.now();
+
+		try {
+			const response = await this.llmService.complete({
+				systemPrompt:
+					'You are a synthesis agent. Given a goal and the findings from specialist agents, ' +
+					'produce a concise, actionable summary and set of recommendations.',
+				userMessage: `Goal: ${goal}\n\nSpecialist Findings:\n${context}\n\nSynthesise the above into a final report.`,
+				maxTokens: 512,
+				temperature: 0.3,
+			});
+
+			const synthContent = response.content || `Goal: ${goal}\n\nFindings:\n${context}`;
+
+			const toolCall: AgentToolCall = {
+				toolId: 'llm-reason',
+				agentId: rootAgent.id,
+				input: `Synthesise: ${goal}`,
+				output: synthContent,
+				success: true,
+				durationMs: Date.now() - callStart,
+				timestamp: Date.now(),
+			};
+			this._recordToolCall(toolCall, runId);
+
+			return synthContent;
+
+		} catch (err) {
+			// Structural fallback synthesis
+			const fallback = `AGI Studio Report — Goal: ${goal}\n\n` +
+				results.map((r, i) => `Finding ${i + 1}: ${r}`).join('\n\n') +
+				'\n\nRecommendation: Review the above findings and apply them to the original goal.';
+
+			const toolCall: AgentToolCall = {
+				toolId: 'llm-reason',
+				agentId: rootAgent.id,
+				input: `Synthesise: ${goal}`,
+				output: fallback,
+				success: false,
+				durationMs: Date.now() - callStart,
+				timestamp: Date.now(),
+			};
+			this._recordToolCall(toolCall, runId);
+
+			return fallback;
+		}
+	}
+
+	// -- Messaging -----------------------------------------------------------
+
+	private _sendMessage(
+		fromAgentId: string,
+		toAgentId: string,
+		messageType: AgentMessageType,
+		content: string,
+		runId: string,
+	): AgentMessage {
+		const msgId = `agi-msg-${Date.now()}-${Math.random().toString(36).slice(2, 5)}`;
+		const message: AgentMessage = {
+			id: msgId,
+			fromAgentId,
+			toAgentId,
+			messageType,
+			content,
+			timestamp: Date.now(),
+		};
+
+		this._messages.set(msgId, message);
+
+		let runMessages = this._runMessages.get(runId);
+		if (!runMessages) {
+			runMessages = [];
+			this._runMessages.set(runId, runMessages);
+		}
+		runMessages.push(msgId);
+
+		this._persistMessageNode(message, runId);
+		this._onDidSendMessage.fire({ ...message });
+
+		return message;
+	}
+
+	// -- Run failure ---------------------------------------------------------
+
+	private _failRun(run: StudioRun, reason: string): void {
+		run.status = 'failed';
+		run.endTime = Date.now();
+		run.result = `Run failed: ${reason}`;
+		this._runs.set(run.id, run);
+
+		if (this._activeRunId === run.id) {
+			this._activeRunId = undefined;
+		}
+
+		this._persistRunNode(run);
+		this.membraneService.recordError('autonomic', `AGI Studio run ${run.id} failed: ${reason}`);
+		this._onDidChangeRun.fire({ ...run });
+
+		this.logService.error(`[AgiStudioService] Run ${run.id} failed: ${reason}`);
+	}
+
+	// -- Tool call tracking --------------------------------------------------
+
+	private _recordToolCall(toolCall: AgentToolCall, runId: string): void {
+		const tcId = `tc-${Date.now()}-${Math.random().toString(36).slice(2, 5)}`;
+		const keyed = { ...toolCall };
+		this._toolCalls.set(tcId, keyed);
+
+		let runCalls = this._runToolCalls.get(runId);
+		if (!runCalls) {
+			runCalls = [];
+			this._runToolCalls.set(runId, runCalls);
+		}
+		runCalls.push(tcId);
+	}
+
+	// -- Hypergraph persistence ----------------------------------------------
+
+	private _persistRunNode(run: StudioRun): void {
+		try {
+			const existing = this.hypergraphStore.getNodesByType('agiStudio.run')
+				.find(n => n.metadata['runId'] === run.id);
+
+			if (existing) {
+				this.hypergraphStore.updateNode(existing.id, {
+					content: JSON.stringify({ status: run.status, goal: run.goal, result: run.result }),
+					metadata: {
+						runId: run.id,
+						status: run.status,
+						startTime: run.startTime,
+						endTime: run.endTime,
+					},
+				});
+			} else {
+				this.hypergraphStore.addNode({
+					node_type: 'agiStudio.run',
+					content: JSON.stringify({ status: run.status, goal: run.goal }),
+					links: [],
+					metadata: {
+						runId: run.id,
+						status: run.status,
+						startTime: run.startTime,
+					},
+					salience_score: 0.8,
+				});
+			}
+		} catch (err) {
+			this.logService.warn('[AgiStudioService] Failed to persist run node:', err);
+		}
+	}
+
+	private _persistAgentNode(agent: StudioAgent, runId: string): void {
+		try {
+			this.hypergraphStore.addNode({
+				node_type: 'agiStudio.agent',
+				content: JSON.stringify({ name: agent.name, role: agent.role, depth: agent.depth }),
+				links: [],
+				metadata: {
+					agentId: agent.id,
+					runId,
+					role: agent.role,
+					depth: agent.depth,
+					superiorId: agent.superiorId ?? null,
+				},
+				salience_score: 0.6,
+			});
+		} catch (err) {
+			this.logService.warn('[AgiStudioService] Failed to persist agent node:', err);
+		}
+	}
+
+	private _persistMessageNode(message: AgentMessage, runId: string): void {
+		try {
+			this.hypergraphStore.addNode({
+				node_type: 'agiStudio.message',
+				content: message.content,
+				links: [],
+				metadata: {
+					messageId: message.id,
+					runId,
+					fromAgentId: message.fromAgentId,
+					toAgentId: message.toAgentId,
+					messageType: message.messageType,
+					timestamp: message.timestamp,
+				},
+				salience_score: 0.4,
+			});
+		} catch (err) {
+			this.logService.warn('[AgiStudioService] Failed to persist message node:', err);
+		}
+	}
+
+	private _persistToolCallNode(toolCall: AgentToolCall, runId: string): void {
+		try {
+			this.hypergraphStore.addNode({
+				node_type: 'agiStudio.toolCall',
+				content: `${toolCall.toolId}: ${toolCall.output.slice(0, 200)}`,
+				links: [],
+				metadata: {
+					runId,
+					agentId: toolCall.agentId,
+					toolId: toolCall.toolId,
+					success: toolCall.success,
+					durationMs: toolCall.durationMs,
+					timestamp: toolCall.timestamp,
+				},
+				salience_score: 0.3,
+			});
+		} catch (err) {
+			this.logService.warn('[AgiStudioService] Failed to persist tool call node:', err);
+		}
+	}
+}

--- a/src/sql/workbench/services/zonecog/browser/agiStudioService.ts
+++ b/src/sql/workbench/services/zonecog/browser/agiStudioService.ts
@@ -480,6 +480,10 @@ export class AgiStudioService extends Disposable implements IAgiStudioService {
 			// Step 3: Synthesise final result
 			const synthesis = await this._synthesiseResults(run.goal, results, rootAgent, run.id);
 
+			if (this._stopRequested.has(run.id)) {
+				return; // stopped during synthesis; stopRun() already finalised state
+			}
+
 			// Mark root agent complete
 			this._setAgentStatus(rootAgent.id, 'completed');
 
@@ -507,6 +511,8 @@ export class AgiStudioService extends Disposable implements IAgiStudioService {
 
 		} catch (err) {
 			this._failRun(run, err instanceof Error ? err.message : String(err));
+		} finally {
+			this._stopRequested.delete(run.id);
 		}
 	}
 
@@ -858,6 +864,9 @@ export class AgiStudioService extends Disposable implements IAgiStudioService {
 	// -- Run failure ---------------------------------------------------------
 
 	private _failRun(run: StudioRun, reason: string): void {
+		if (run.status !== 'running') {
+			return; // never overwrite a stopped/completed run
+		}
 		run.status = 'failed';
 		run.endTime = Date.now();
 		run.result = `Run failed: ${reason}`;

--- a/src/sql/workbench/services/zonecog/browser/zonecog.contribution.ts
+++ b/src/sql/workbench/services/zonecog/browser/zonecog.contribution.ts
@@ -35,6 +35,8 @@ import { PerformanceAdvisorAgent } from 'sql/workbench/services/zonecog/browser/
 import { DataPatternAgent } from 'sql/workbench/services/zonecog/browser/dataPatternAgent';
 import { ICognitiveWorkflowAutomationService } from 'sql/workbench/services/zonecog/common/cognitiveWorkflowAutomation';
 import { CognitiveWorkflowAutomationService } from 'sql/workbench/services/zonecog/browser/cognitiveWorkflowAutomationService';
+import { IAgiStudioService } from 'sql/workbench/services/zonecog/common/agiStudio';
+import { AgiStudioService } from 'sql/workbench/services/zonecog/browser/agiStudioService';
 
 // Register the Hypergraph store (dependency of ZoneCogService)
 registerSingleton(IHypergraphStore, HypergraphStore, InstantiationType.Eager);
@@ -94,6 +96,11 @@ registerSingleton(IDataPatternAgent, DataPatternAgent, InstantiationType.Eager);
 
 // Register the Cognitive Workflow Automation service (custom workflow DSL execution)
 registerSingleton(ICognitiveWorkflowAutomationService, CognitiveWorkflowAutomationService, InstantiationType.Eager);
+
+// Register Phase 7 services
+
+// Register the AGI Studio service (Agent-Zero-style hierarchical autonomous agents)
+registerSingleton(IAgiStudioService, AgiStudioService, InstantiationType.Eager);
 
 // Register the ZoneCog service as a singleton
 registerSingleton(IZoneCogService, ZoneCogService, InstantiationType.Eager);

--- a/src/sql/workbench/services/zonecog/common/agiStudio.ts
+++ b/src/sql/workbench/services/zonecog/common/agiStudio.ts
@@ -1,0 +1,265 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
+import { Event } from 'vs/base/common/event';
+
+export const IAgiStudioService = createDecorator<IAgiStudioService>('agiStudioService');
+
+// ---------------------------------------------------------------------------
+// Studio Agent types
+// ---------------------------------------------------------------------------
+
+/**
+ * Roles that studio agents can play in the Agent-Zero hierarchy.
+ */
+export type StudioAgentRole =
+	| 'orchestrator'       // Root agent that decomposes the goal
+	| 'sql-analyzer'       // Wraps ISQLAnalyzerAgent
+	| 'schema-reasoner'    // Wraps ISchemaReasonerAgent
+	| 'performance-advisor'// Wraps IPerformanceAdvisorAgent
+	| 'data-pattern'       // Wraps IDataPatternAgent
+	| 'llm-reasoner'       // Uses ILLMProviderService directly
+	| 'synthesizer';       // Synthesizes subordinate results
+
+/**
+ * Status of an individual studio agent.
+ */
+export type StudioAgentStatus = 'idle' | 'running' | 'completed' | 'failed' | 'stopped';
+
+/**
+ * A single entry in an agent's local (agent-scoped) memory.
+ */
+export interface StudioAgentMemoryItem {
+	/** Memory key used for recall. */
+	key: string;
+	/** Stored value. */
+	value: string;
+	/** Epoch-ms when this item was stored. */
+	timestamp: number;
+}
+
+/**
+ * An autonomous Studio Agent in the Agent-Zero hierarchy.
+ *
+ * Agents form a tree rooted at depth 0 (the orchestrator). Each agent can
+ * spawn subordinates (depth+1) up to the configured maximum depth.
+ */
+export interface StudioAgent {
+	/** Unique identifier for this agent within the run. */
+	id: string;
+	/** Human-readable display name. */
+	name: string;
+	/** Functional role of this agent. */
+	role: StudioAgentRole;
+	/** ID of the agent that spawned this one (undefined for the root). */
+	superiorId: string | undefined;
+	/** IDs of agents spawned by this agent. */
+	subordinateIds: string[];
+	/** Current lifecycle status. */
+	status: StudioAgentStatus;
+	/** Depth in the agent tree (root = 0). */
+	depth: number;
+	/** System prompt injected at construction time. */
+	systemPrompt: string;
+	/** Epoch-ms when this agent was created. */
+	createdAt: number;
+	/** Agent-local memory items (key-value pairs). */
+	localMemory: StudioAgentMemoryItem[];
+}
+
+// ---------------------------------------------------------------------------
+// Agent message types
+// ---------------------------------------------------------------------------
+
+/**
+ * Types of messages agents exchange in the hierarchy.
+ */
+export type AgentMessageType =
+	| 'task-assignment'  // Superior assigns a subtask to a subordinate
+	| 'result-report'    // Subordinate reports its result back to its superior
+	| 'status-update';   // Agent broadcasts a status change
+
+/**
+ * A message passed between two agents in the hierarchy.
+ */
+export interface AgentMessage {
+	/** Unique identifier. */
+	id: string;
+	/** Agent ID of the sender. */
+	fromAgentId: string;
+	/** Agent ID of the receiver. */
+	toAgentId: string;
+	/** Semantic type of the message. */
+	messageType: AgentMessageType;
+	/** Message payload as a human-readable string. */
+	content: string;
+	/** Epoch-ms timestamp. */
+	timestamp: number;
+}
+
+// ---------------------------------------------------------------------------
+// Studio Run types
+// ---------------------------------------------------------------------------
+
+/**
+ * Lifecycle status of a studio run.
+ */
+export type StudioRunStatus = 'running' | 'completed' | 'failed' | 'stopped';
+
+/**
+ * A single end-to-end autonomous run triggered by a user goal.
+ *
+ * A run creates a root orchestrator agent which decomposes the goal and
+ * delegates subtasks to subordinate agents.  The run is complete when the
+ * root agent synthesizes a final result.
+ */
+export interface StudioRun {
+	/** Unique run identifier. */
+	id: string;
+	/** The top-level goal provided by the user. */
+	goal: string;
+	/** ID of the root orchestrator agent. */
+	rootAgentId: string;
+	/** Current lifecycle status. */
+	status: StudioRunStatus;
+	/** Epoch-ms when the run started. */
+	startTime: number;
+	/** Epoch-ms when the run finished (undefined while running). */
+	endTime?: number;
+	/** Synthesized result string (set on completion). */
+	result?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Tool types
+// ---------------------------------------------------------------------------
+
+/**
+ * Record of a single tool invocation by an agent.
+ */
+export interface AgentToolCall {
+	/** Tool identifier. */
+	toolId: string;
+	/** ID of the agent that invoked the tool. */
+	agentId: string;
+	/** Serialised input passed to the tool. */
+	input: string;
+	/** Serialised output returned by the tool. */
+	output: string;
+	/** Whether the invocation succeeded. */
+	success: boolean;
+	/** Wall-clock time in milliseconds for the invocation. */
+	durationMs: number;
+	/** Epoch-ms timestamp of the invocation. */
+	timestamp: number;
+}
+
+/**
+ * A tool that an agent can invoke to accomplish part of its task.
+ */
+export interface AgentTool {
+	/** Unique tool identifier. */
+	id: string;
+	/** Human-readable tool name. */
+	name: string;
+	/** One-line description of what this tool does. */
+	description: string;
+	/** Invoke the tool with the given input text and calling agent context. */
+	invoke(input: string, agent: StudioAgent): Promise<string>;
+}
+
+// ---------------------------------------------------------------------------
+// Service interface
+// ---------------------------------------------------------------------------
+
+/**
+ * AGI Studio Service — Agent-Zero-style hierarchical autonomous agents.
+ *
+ * Provides an Agent-Zero-inspired orchestration layer on top of the ZoneCog
+ * cognitive services.  A root studio agent receives a high-level goal,
+ * decomposes it into subtasks using the LLM provider, delegates each subtask
+ * to a spawned subordinate agent, and synthesises a final result.
+ *
+ * Agents communicate via typed {@link AgentMessage}s (task-assignment /
+ * result-report / status-update).  Each agent has an agent-local memory store
+ * and may invoke any registered {@link AgentTool}.  All run/agent/message
+ * state is persisted as hypergraph nodes.
+ */
+export interface IAgiStudioService {
+	readonly _serviceBrand: undefined;
+
+	/** Fired whenever a run's status changes (created, completed, failed, stopped). */
+	readonly onDidChangeRun: Event<StudioRun>;
+
+	/** Fired whenever a new subordinate agent is spawned. */
+	readonly onDidSpawnAgent: Event<StudioAgent>;
+
+	/** Fired whenever an agent sends a message to another agent. */
+	readonly onDidSendMessage: Event<AgentMessage>;
+
+	// -- Run management ------------------------------------------------------
+
+	/**
+	 * Start an autonomous run for the given user goal.
+	 *
+	 * Immediately spawns a root orchestrator agent, fires `onDidSpawnAgent`,
+	 * then executes the full autonomous loop asynchronously.  Returns the
+	 * initial run object (status = 'running'); subscribe to `onDidChangeRun`
+	 * to observe completion.
+	 *
+	 * Any previously active run is stopped before starting the new one.
+	 */
+	startRun(goal: string): Promise<StudioRun>;
+
+	/**
+	 * Stop a running run.  Marks the run as 'stopped' synchronously and fires
+	 * `onDidChangeRun`.  The async execution loop respects the stop flag and
+	 * exits at its next checkpoint.
+	 *
+	 * @param runId  The run to stop.  Defaults to the currently active run.
+	 */
+	stopRun(runId?: string): void;
+
+	/**
+	 * Get the currently active (running) run, or undefined if none.
+	 */
+	getActiveRun(): StudioRun | undefined;
+
+	/**
+	 * Get all runs ever started in this session (newest first).
+	 */
+	getRuns(): StudioRun[];
+
+	// -- Query helpers -------------------------------------------------------
+
+	/**
+	 * Get all agents belonging to a given run (or all agents if no runId).
+	 */
+	getAgents(runId?: string): StudioAgent[];
+
+	/**
+	 * Get all messages belonging to a given run (or all messages).
+	 */
+	getMessages(runId?: string): AgentMessage[];
+
+	/**
+	 * Get all tool-call records belonging to a given run (or all calls).
+	 */
+	getToolCalls(runId?: string): AgentToolCall[];
+
+	// -- Tool registry -------------------------------------------------------
+
+	/**
+	 * Get all registered agent tools.
+	 */
+	getTools(): AgentTool[];
+
+	/**
+	 * Register a new agent tool.  No-op if a tool with the same ID already
+	 * exists.
+	 */
+	registerTool(tool: AgentTool): void;
+}

--- a/src/sql/workbench/services/zonecog/test/browser/agiStudioService.test.ts
+++ b/src/sql/workbench/services/zonecog/test/browser/agiStudioService.test.ts
@@ -406,6 +406,24 @@ suite('AGI Studio Service Tests', () => {
 		assert.doesNotThrow(() => service.stopRun(), 'Should not throw when no active run');
 	});
 
+	test('stopped run must never be resurrected to completed or failed', async () => {
+		const run = await service.startRun('long analysis task stopped mid-flight');
+		service.stopRun(run.id);
+
+		// Let the in-flight async executor fully settle past synthesis/error paths
+		await new Promise<void>(resolve => setTimeout(resolve, 250));
+
+		const settled = service.getRuns().find(r => r.id === run.id);
+		assert.ok(settled, 'Run should still exist after executor settles');
+		assert.strictEqual(settled!.status, 'stopped', 'Status must remain stopped after executor settles');
+		assert.strictEqual(service.getActiveRun(), undefined, 'No active run after stop');
+
+		// A subsequent run must start cleanly despite the earlier stop
+		const next = await service.startRun('follow-up goal after stop');
+		const completed = await waitForRunComplete(next.id);
+		assert.strictEqual(completed.status, 'completed', 'Follow-up run should complete normally');
+	});
+
 	// -- Test 12: Multiple runs ----------------------------------------------
 
 	test('should handle multiple sequential runs and maintain history', async () => {

--- a/src/sql/workbench/services/zonecog/test/browser/agiStudioService.test.ts
+++ b/src/sql/workbench/services/zonecog/test/browser/agiStudioService.test.ts
@@ -1,0 +1,434 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { IAgiStudioService, StudioRun } from 'sql/workbench/services/zonecog/common/agiStudio';
+import { AgiStudioService } from 'sql/workbench/services/zonecog/browser/agiStudioService';
+import { IHypergraphStore, ICognitiveMembraneService } from 'sql/workbench/services/zonecog/common/zonecogService';
+import { HypergraphStore } from 'sql/workbench/services/zonecog/browser/hypergraphStore';
+import { CognitiveMembraneService } from 'sql/workbench/services/zonecog/browser/cognitiveMembraneService';
+import { ILLMProviderService } from 'sql/workbench/services/zonecog/common/llmProvider';
+import { LLMProviderService } from 'sql/workbench/services/zonecog/browser/llmProviderService';
+import { ICognitiveWorkspaceService } from 'sql/workbench/services/zonecog/common/cognitiveWorkspace';
+import { CognitiveWorkspaceService } from 'sql/workbench/services/zonecog/browser/cognitiveWorkspaceService';
+import { ISQLAnalyzerAgent } from 'sql/workbench/services/zonecog/common/cognitiveAgents';
+import { SQLAnalyzerAgent } from 'sql/workbench/services/zonecog/browser/sqlAnalyzerAgent';
+import { ISchemaReasonerAgent } from 'sql/workbench/services/zonecog/common/cognitiveAgents';
+import { SchemaReasonerAgent } from 'sql/workbench/services/zonecog/browser/schemaReasonerAgent';
+import { IPerformanceAdvisorAgent } from 'sql/workbench/services/zonecog/common/cognitiveAgents';
+import { PerformanceAdvisorAgent } from 'sql/workbench/services/zonecog/browser/performanceAdvisorAgent';
+import { IDataPatternAgent } from 'sql/workbench/services/zonecog/common/cognitiveAgents';
+import { DataPatternAgent } from 'sql/workbench/services/zonecog/browser/dataPatternAgent';
+import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
+import { ILogService, NullLogService } from 'vs/platform/log/common/log';
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+suite('AGI Studio Service Tests', () => {
+
+	let instantiationService: TestInstantiationService;
+	let service: IAgiStudioService;
+
+	/** Helper: wait for a run to reach a terminal status via the event. */
+	function waitForRunComplete(runId: string, timeoutMs = 10000): Promise<StudioRun> {
+		return new Promise<StudioRun>((resolve, reject) => {
+			const timer = setTimeout(() => reject(new Error(`Run ${runId} did not complete within ${timeoutMs}ms`)), timeoutMs);
+			service.onDidChangeRun(run => {
+				if (run.id === runId && (run.status === 'completed' || run.status === 'failed' || run.status === 'stopped')) {
+					clearTimeout(timer);
+					resolve(run);
+				}
+			});
+		});
+	}
+
+	setup(() => {
+		instantiationService = new TestInstantiationService();
+		instantiationService.stub(ILogService, new NullLogService());
+
+		// Register real dependency instances (not mocks)
+		const hypergraphStore = instantiationService.createInstance(HypergraphStore);
+		instantiationService.stub(IHypergraphStore, hypergraphStore);
+
+		const membraneService = instantiationService.createInstance(CognitiveMembraneService);
+		instantiationService.stub(ICognitiveMembraneService, membraneService);
+
+		const llmService = instantiationService.createInstance(LLMProviderService);
+		instantiationService.stub(ILLMProviderService, llmService);
+
+		const workspaceService = instantiationService.createInstance(CognitiveWorkspaceService);
+		instantiationService.stub(ICognitiveWorkspaceService, workspaceService);
+
+		const sqlAgent = instantiationService.createInstance(SQLAnalyzerAgent);
+		instantiationService.stub(ISQLAnalyzerAgent, sqlAgent);
+
+		const schemaAgent = instantiationService.createInstance(SchemaReasonerAgent);
+		instantiationService.stub(ISchemaReasonerAgent, schemaAgent);
+
+		const perfAgent = instantiationService.createInstance(PerformanceAdvisorAgent);
+		instantiationService.stub(IPerformanceAdvisorAgent, perfAgent);
+
+		const dataAgent = instantiationService.createInstance(DataPatternAgent);
+		instantiationService.stub(IDataPatternAgent, dataAgent);
+
+		service = instantiationService.createInstance(AgiStudioService);
+	});
+
+	// -- Test 1: Service initialization --------------------------------------
+
+	test('service should initialise with 7 built-in tools', () => {
+		const tools = service.getTools();
+		assert.ok(tools.length >= 7, `Expected ≥7 tools, got ${tools.length}`);
+
+		const toolIds = tools.map(t => t.id);
+		assert.ok(toolIds.includes('sql-analyze'), 'sql-analyze tool should be registered');
+		assert.ok(toolIds.includes('schema-reason'), 'schema-reason tool should be registered');
+		assert.ok(toolIds.includes('perf-advise'), 'perf-advise tool should be registered');
+		assert.ok(toolIds.includes('data-pattern'), 'data-pattern tool should be registered');
+		assert.ok(toolIds.includes('llm-reason'), 'llm-reason tool should be registered');
+		assert.ok(toolIds.includes('memory-save'), 'memory-save tool should be registered');
+		assert.ok(toolIds.includes('memory-recall'), 'memory-recall tool should be registered');
+	});
+
+	test('service should start with no active run', () => {
+		assert.strictEqual(service.getActiveRun(), undefined, 'No active run expected initially');
+		assert.strictEqual(service.getRuns().length, 0, 'No runs expected initially');
+	});
+
+	// -- Test 2: Tool registry -----------------------------------------------
+
+	test('should support registering custom tools', () => {
+		const initialCount = service.getTools().length;
+
+		service.registerTool({
+			id: 'custom-test-tool',
+			name: 'Custom Test Tool',
+			description: 'A test tool',
+			invoke: async () => 'custom-result',
+		});
+
+		assert.strictEqual(service.getTools().length, initialCount + 1, 'Custom tool should be registered');
+
+		// Registering the same ID again should be a no-op
+		service.registerTool({
+			id: 'custom-test-tool',
+			name: 'Duplicate',
+			description: 'Duplicate tool',
+			invoke: async () => 'ignored',
+		});
+
+		assert.strictEqual(service.getTools().length, initialCount + 1, 'Duplicate tool should not increase count');
+	});
+
+	// -- Test 3: Run lifecycle -----------------------------------------------
+
+	test('should complete a run with non-empty result', async () => {
+		const completedP = waitForRunComplete('', 10000);
+		let capturedRunId = '';
+
+		const runStarted = new Promise<void>(resolve => {
+			service.onDidSpawnAgent(() => resolve());
+		});
+
+		const run = await service.startRun('analyze sql query performance patterns');
+		capturedRunId = run.id;
+
+		assert.ok(run.id, 'Run should have an ID');
+		assert.strictEqual(run.status, 'running', 'Run should start in running state');
+		assert.strictEqual(run.goal, 'analyze sql query performance patterns');
+		assert.ok(run.rootAgentId, 'Run should have a root agent ID');
+
+		// Replace placeholder promise with actual run ID
+		const completedRun = await waitForRunComplete(run.id, 10000);
+
+		assert.strictEqual(completedRun.id, run.id, 'Completed run should have same ID');
+		assert.strictEqual(completedRun.status, 'completed', 'Run should complete successfully');
+		assert.ok(completedRun.result, 'Run should have a non-empty result');
+		assert.ok(completedRun.result.length > 0, 'Result should have content');
+		assert.ok(completedRun.endTime !== undefined, 'End time should be set');
+		assert.ok(completedRun.endTime! >= run.startTime, 'End time should be after start time');
+
+		// Suppress unused variable warning
+		void runStarted;
+		void capturedRunId;
+		void completedP;
+	});
+
+	test('should return run in getRuns after completion', async () => {
+		const run = await service.startRun('test run for history');
+		await waitForRunComplete(run.id);
+
+		const runs = service.getRuns();
+		assert.ok(runs.length >= 1, 'getRuns should return at least one run');
+		assert.ok(runs.some(r => r.id === run.id), 'The run should appear in getRuns');
+	});
+
+	// -- Test 4: Hierarchical spawning ---------------------------------------
+
+	test('should spawn subordinate agents with correct superiorId and depth', async () => {
+		const run = await service.startRun('analyze sql schema relationships in database');
+		await waitForRunComplete(run.id);
+
+		const agents = service.getAgents(run.id);
+		assert.ok(agents.length >= 2, `Expected ≥2 agents, got ${agents.length}`);
+
+		const root = agents.find(a => a.superiorId === undefined);
+		assert.ok(root, 'Root agent with no superiorId should exist');
+		assert.strictEqual(root!.depth, 0, 'Root agent should be at depth 0');
+		assert.strictEqual(root!.role, 'orchestrator', 'Root agent should have orchestrator role');
+
+		const subordinates = agents.filter(a => a.superiorId === root!.id);
+		assert.ok(subordinates.length >= 1, 'At least one subordinate should be spawned');
+
+		for (const sub of subordinates) {
+			assert.strictEqual(sub.superiorId, root!.id, 'Subordinate should reference root as superior');
+			assert.strictEqual(sub.depth, 1, 'Subordinates should be at depth 1');
+		}
+	});
+
+	test('should enforce max total agent cap (8) per run', async () => {
+		const run = await service.startRun('very complex analysis involving sql schema performance data patterns');
+		await waitForRunComplete(run.id);
+
+		const agents = service.getAgents(run.id);
+		assert.ok(agents.length <= 8, `Agent count ${agents.length} should not exceed MAX_AGENTS_PER_RUN=8`);
+	});
+
+	// -- Test 5: Inter-agent messaging ---------------------------------------
+
+	test('should produce task-assignment and result-report messages', async () => {
+		const run = await service.startRun('analyze performance of SQL queries');
+		await waitForRunComplete(run.id);
+
+		const messages = service.getMessages(run.id);
+		assert.ok(messages.length >= 2, `Expected ≥2 messages, got ${messages.length}`);
+
+		const taskAssignments = messages.filter(m => m.messageType === 'task-assignment');
+		const resultReports = messages.filter(m => m.messageType === 'result-report');
+
+		assert.ok(taskAssignments.length >= 1, 'At least one task-assignment message expected');
+		assert.ok(resultReports.length >= 1, 'At least one result-report message expected');
+
+		// Task assignments should be from root to subordinates
+		const agents = service.getAgents(run.id);
+		const root = agents.find(a => a.superiorId === undefined);
+		assert.ok(root, 'Root agent must exist');
+
+		for (const ta of taskAssignments) {
+			assert.strictEqual(ta.fromAgentId, root!.id, 'Task assignment from should be root');
+			assert.ok(ta.content.length > 0, 'Task assignment content should not be empty');
+		}
+
+		// Result reports should be from subordinates to root
+		for (const rr of resultReports) {
+			assert.strictEqual(rr.toAgentId, root!.id, 'Result report to should be root');
+			assert.ok(rr.content.length > 0, 'Result report content should not be empty');
+		}
+	});
+
+	// -- Test 6: Tool calls --------------------------------------------------
+
+	test('should record tool calls for agent tasks', async () => {
+		const run = await service.startRun('analyze sql query structure and performance');
+		await waitForRunComplete(run.id);
+
+		const toolCalls = service.getToolCalls(run.id);
+		assert.ok(toolCalls.length >= 2, `Expected ≥2 tool calls, got ${toolCalls.length}`);
+
+		for (const tc of toolCalls) {
+			assert.ok(tc.toolId, 'Tool call should have toolId');
+			assert.ok(tc.agentId, 'Tool call should have agentId');
+			assert.ok(tc.input.length > 0, 'Tool call input should not be empty');
+			assert.ok(tc.output.length > 0, 'Tool call output should not be empty');
+			assert.ok(tc.durationMs >= 0, 'Duration should be non-negative');
+			assert.ok(tc.timestamp > 0, 'Timestamp should be set');
+		}
+	});
+
+	// -- Test 7: Agent-local memory ------------------------------------------
+
+	test('should save and recall agent-local memory via memory tools', async () => {
+		const memSaveTool = service.getTools().find(t => t.id === 'memory-save');
+		const memRecallTool = service.getTools().find(t => t.id === 'memory-recall');
+
+		assert.ok(memSaveTool, 'memory-save tool should exist');
+		assert.ok(memRecallTool, 'memory-recall tool should exist');
+
+		// Create a mock agent
+		const mockAgent = {
+			id: 'test-agent-memory',
+			name: 'Test Agent',
+			role: 'llm-reasoner' as const,
+			superiorId: undefined,
+			subordinateIds: [],
+			status: 'idle' as const,
+			depth: 0,
+			systemPrompt: 'test',
+			createdAt: Date.now(),
+			localMemory: [],
+		};
+
+		// Save a key-value pair
+		const saveResult = await memSaveTool!.invoke('analysis-result::SQL performance degradation detected', mockAgent);
+		assert.ok(saveResult.includes('Saved'), 'Save should confirm success');
+
+		// Verify the agent's local memory was updated
+		assert.ok(mockAgent.localMemory.length >= 1, 'Agent local memory should have one entry');
+		assert.strictEqual(mockAgent.localMemory[0].key, 'analysis-result', 'Key should match');
+		assert.ok(mockAgent.localMemory[0].value.includes('SQL'), 'Value should contain saved content');
+
+		// Recall by keyword
+		const recallResult = await memRecallTool!.invoke('analysis', mockAgent);
+		assert.ok(recallResult.length > 0, 'Recall should return non-empty result');
+		assert.ok(!recallResult.startsWith('No memories found'), 'Should find memory by keyword');
+	});
+
+	// -- Test 8: Hypergraph persistence -------------------------------------
+
+	test('should persist run, agent, and message nodes to hypergraph', async () => {
+		const hypergraphStore = instantiationService.get(IHypergraphStore);
+		const nodesBefore = hypergraphStore.getAllNodes().length;
+
+		const run = await service.startRun('schema analysis for persistence test');
+		await waitForRunComplete(run.id);
+
+		const allNodes = hypergraphStore.getAllNodes();
+		assert.ok(allNodes.length > nodesBefore, 'Nodes should be added to hypergraph');
+
+		const runNodes = hypergraphStore.getNodesByType('agiStudio.run');
+		const agentNodes = hypergraphStore.getNodesByType('agiStudio.agent');
+		const messageNodes = hypergraphStore.getNodesByType('agiStudio.message');
+		const toolCallNodes = hypergraphStore.getNodesByType('agiStudio.toolCall');
+
+		assert.ok(runNodes.length >= 1, 'At least one agiStudio.run node expected');
+		assert.ok(agentNodes.length >= 2, 'At least two agiStudio.agent nodes expected');
+		assert.ok(messageNodes.length >= 2, 'At least two agiStudio.message nodes expected');
+		assert.ok(toolCallNodes.length >= 1, 'At least one agiStudio.toolCall node expected');
+
+		// Verify run node metadata
+		const runNode = runNodes.find(n => n.metadata['runId'] === run.id);
+		assert.ok(runNode, 'Run node should have runId in metadata');
+		assert.strictEqual(runNode!.metadata['status'], 'completed', 'Run node status should be completed');
+
+		// Verify agent node metadata
+		const agentNode = agentNodes.find(n => n.metadata['runId'] === run.id);
+		assert.ok(agentNode, 'Agent node should reference runId');
+		assert.ok(agentNode!.metadata['role'], 'Agent node should have role in metadata');
+	});
+
+	// -- Test 9: Membrane activity ------------------------------------------
+
+	test('should record membrane activity during run', async () => {
+		const membraneService = instantiationService.get(ICognitiveMembraneService);
+
+		const cerebralBefore = membraneService.getActivity('cerebral');
+		const somaticBefore = membraneService.getActivity('somatic');
+
+		const run = await service.startRun('test membrane activity recording');
+		await waitForRunComplete(run.id);
+
+		const cerebralAfter = membraneService.getActivity('cerebral');
+		const somaticAfter = membraneService.getActivity('somatic');
+
+		assert.ok(cerebralAfter > cerebralBefore, 'Cerebral membrane should have activity > before');
+		assert.ok(somaticAfter > somaticBefore, 'Somatic membrane should have activity > before');
+	});
+
+	// -- Test 10: Event firing -----------------------------------------------
+
+	test('should fire onDidSpawnAgent for each spawned agent', async () => {
+		const spawnedAgentIds: string[] = [];
+		service.onDidSpawnAgent(agent => spawnedAgentIds.push(agent.id));
+
+		const run = await service.startRun('analyze data patterns in schema');
+		await waitForRunComplete(run.id);
+
+		const agents = service.getAgents(run.id);
+		assert.ok(spawnedAgentIds.length >= 2, `Expected ≥2 spawned events, got ${spawnedAgentIds.length}`);
+
+		// All spawned agent IDs should match actual agents
+		for (const id of spawnedAgentIds) {
+			assert.ok(agents.some(a => a.id === id), `Spawned agent ${id} should be in agent list`);
+		}
+	});
+
+	test('should fire onDidSendMessage for each inter-agent message', async () => {
+		const receivedMessages: Array<{ from: string; to: string; type: string }> = [];
+		service.onDidSendMessage(msg => receivedMessages.push({
+			from: msg.fromAgentId,
+			to: msg.toAgentId,
+			type: msg.messageType,
+		}));
+
+		const run = await service.startRun('analyze sql query structure');
+		await waitForRunComplete(run.id);
+
+		assert.ok(receivedMessages.length >= 2, `Expected ≥2 message events, got ${receivedMessages.length}`);
+
+		const hasTaskAssignment = receivedMessages.some(m => m.type === 'task-assignment');
+		const hasResultReport = receivedMessages.some(m => m.type === 'result-report');
+
+		assert.ok(hasTaskAssignment, 'onDidSendMessage should fire for task-assignment');
+		assert.ok(hasResultReport, 'onDidSendMessage should fire for result-report');
+	});
+
+	// -- Test 11: stopRun behavior -------------------------------------------
+
+	test('should mark run as stopped immediately when stopRun is called', async () => {
+		// Collect events
+		const stateChanges: string[] = [];
+		service.onDidChangeRun(run => stateChanges.push(run.status));
+
+		const run = await service.startRun('long analysis task to be stopped');
+
+		// Stop immediately (before async execution can complete)
+		service.stopRun(run.id);
+
+		// The run should already be marked stopped
+		const runs = service.getRuns();
+		const stoppedRun = runs.find(r => r.id === run.id);
+		assert.ok(stoppedRun, 'Run should still exist after stopping');
+		assert.strictEqual(stoppedRun!.status, 'stopped', 'Run should be stopped immediately');
+
+		// Active run should be cleared
+		assert.strictEqual(service.getActiveRun(), undefined, 'No active run after stop');
+
+		// Events should include 'stopped' state
+		assert.ok(stateChanges.includes('stopped'), 'stopped event should be fired');
+	});
+
+	test('stopRun on non-existent ID should be a no-op', () => {
+		assert.doesNotThrow(() => service.stopRun('non-existent-run-id'), 'Should not throw for unknown run');
+		assert.doesNotThrow(() => service.stopRun(), 'Should not throw when no active run');
+	});
+
+	// -- Test 12: Multiple runs ----------------------------------------------
+
+	test('should handle multiple sequential runs and maintain history', async () => {
+		const run1 = await service.startRun('first analysis goal');
+		await waitForRunComplete(run1.id);
+
+		const run2 = await service.startRun('second analysis goal');
+		await waitForRunComplete(run2.id);
+
+		const allRuns = service.getRuns();
+		assert.ok(allRuns.length >= 2, 'Should have at least 2 runs in history');
+		assert.ok(allRuns.some(r => r.id === run1.id), 'First run should be in history');
+		assert.ok(allRuns.some(r => r.id === run2.id), 'Second run should be in history');
+
+		// Messages from different runs should be separate
+		const msgs1 = service.getMessages(run1.id);
+		const msgs2 = service.getMessages(run2.id);
+		assert.ok(msgs1.length >= 1, 'First run should have messages');
+		assert.ok(msgs2.length >= 1, 'Second run should have messages');
+
+		// No cross-contamination of messages
+		for (const m1 of msgs1) {
+			assert.ok(!msgs2.some(m2 => m2.id === m1.id), 'Messages should not overlap between runs');
+		}
+	});
+});


### PR DESCRIPTION
## Description

Adds an **AGI Studio** subsystem to the Zone-Cog cognitive workbench: an Agent-Zero-inspired hierarchical autonomous agent orchestration layer. Until now, ZoneCog agents were flat peers routed centrally by the AAR orchestrator, with no agent spawning, delegation, or inter-agent messaging. This PR closes that gap so users can hand the workbench a goal and watch it decompose, delegate, and solve it autonomously.

**How it works:**

- `IAgiStudioService` (`common/agiStudio.ts`, `browser/agiStudioService.ts`): `startRun(goal)` creates a root orchestrator agent (depth 0) that decomposes the goal via `ILLMProviderService` and spawns specialist subordinate agents (depth <= 2, max 8 agents/run). Delegation flows as `AgentMessage`s (task-assignment down, result-report up), and the root synthesizes a final result. `stopRun()` halts mid-flight.
- **Deterministic keyless fallback**: when the LLM provider returns its built-in fallback response, a keyword-based structural decomposition path runs instead, so runs always complete without API keys.
- **7 tools** wrap existing services as agent capabilities: sql-analyze, schema-reason, perf-advise, data-pattern (the four specialized cognitive agents), llm-reason, memory-save, memory-recall. Every invocation is recorded as an `AgentToolCall`.
- **Full ZoneCog integration**: membrane activity recorded per triad (cerebral for reasoning, somatic for tool/LLM calls, autonomic for guards); runs, agents, messages, and tool calls persisted as EchoCog `HypergraphNode`s with typed links; agent-local memory alongside shared workspace episodic memory; service registered Eager in `zonecog.contribution.ts`.
- **UI**: new `AgiStudioView` (order 8) in the Zone-Cog panel showing run status, the live agent hierarchy tree, and recent messages, refreshing reactively via service events. Three new Command Palette actions: `zonecog.agiStudio.startRun`, `showStatus`, `stopRun`.

**Notes for reviewers:**

- Existing `AAROrchestrationService` and `CognitiveWorkflowAutomationService` contracts are untouched; the Studio consumes services but changes none.
- Built via the goal skill's Builder/Inspector loop; verification artifacts live in `.goals/zonecog-agi-studio/` (goal spec, inspector verdict, summary).
- Quality gate: `tsc --noEmit -p src/tsconfig.json` reports zero zonecog/agiStudio errors (6 pre-existing TS2688 baseline lines from `--ignore-scripts` installs remain, within the 16-line baseline).

## Code Changes Checklist

- [x] New or updated **unit tests** added (`agiStudioService.test.ts`, 17 cases with real dependency instances)
- [ ] All existing tests pass (`npm run test`) — full compiled test run not possible in this environment; verified via TypeScript type-check gate
- [x] Code follows [contributing guidelines](https://github.com/microsoft/azuredatastudio/blob/main/CONTRIBUTING.md)
- [x] No UI regressions introduced (new view added at free order slot; existing views untouched)
- [x] Logging/telemetry updated if applicable (ILogService logging throughout; membrane activity recording)
- [x] Cross-platform support checked (Windows, macOS, Linux if relevant) — browser-layer TypeScript only, no platform-specific code

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/azuredatastudio/blob/main/.github/REVIEW_GUIDELINES.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new orchestration surface (~1k LOC service) with async runs and LLM/tool integration, but it consumes existing ZoneCog services without altering AAR or workflow contracts; coverage is strong at the type/test level though full mocha was not run in this environment.
> 
> **Overview**
> Introduces **AGI Studio**, a new Zone-Cog capability for hierarchical autonomous runs: a user goal drives a root orchestrator that decomposes work, spawns specialist subordinates (depth ≤ 2, cap 8 agents), exchanges **task-assignment** / **result-report** messages, invokes tools, and synthesizes a final result.
> 
> **Service layer:** New `IAgiStudioService` (`common/agiStudio.ts`) and `AgiStudioService` (`browser/agiStudioService.ts`) with `startRun` / `stopRun`, run queries, and events (`onDidChangeRun`, `onDidSpawnAgent`, `onDidSendMessage`). Decomposition and synthesis go through `ILLMProviderService`; a keyword-based fallback keeps runs completing without API keys. Seven built-in tools wrap existing cognitive agents plus LLM and memory save/recall; runs persist to the hypergraph and record membrane activity. Registered **Eager** in `zonecog.contribution.ts`.
> 
> **Workbench:** `AgiStudioView` (Zone-Cog panel, order 8) shows run status, agent tree, and recent messages. Three Command Palette actions: start run (goal prompt), show status, stop run. README documents the subsystem.
> 
> **Tests:** `agiStudioService.test.ts` (17 cases) uses real dependency instances via `TestInstantiationService` for lifecycle, spawning caps, messaging, tools, hypergraph, membrane, events, and stop semantics.
> 
> Goal/inspector artifacts under `.goals/zonecog-agi-studio/` are documentation only; AAR and workflow automation contracts are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27a9b0fbfa9364c7868203b34867102abe35234c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->