### PR TITLE
Revert "feat(zonecog): mine interaction history for cognitive patterns"

### DIFF
--- a/.github/agents/zonecog.agent.md
+++ b/.github/agents/zonecog.agent.md
@@ -84,7 +84,6 @@ Depth-adaptive: shallow (phases 1,2,11), moderate (1-5,11), deep (all 11).
 - `CognitiveEpisode` — Temporal event records
 - `TaskContext` — Goal-oriented task groupings
 - `AttentionFocus` — ECAN attention allocation targets
-- `InteractionPattern` — Recognized frequency/sequence/temporal patterns in interaction history
 
 ### Membrane Triads (P-System Architecture)
 
@@ -287,7 +286,6 @@ This file is imported by:
 | `zonecog.membraneHealth` | Show membrane triad health |
 | `zonecog.reset` | Reset entire cognitive workbench |
 | `zonecog.queryHistory` | Show query processing history |
-| `zonecog.detectInteractionPatterns` | Mine interaction history for frequency/sequence/temporal patterns |
 
 ### Event Bus
 
@@ -299,7 +297,6 @@ Key events for inter-service communication:
 - `onDidChangeNode` / `onDidChangeLink` — Hypergraph mutations
 - `onDidChangeMembraneStatus` — Membrane health changes
 - `onDidPerceive` / `onDidAct` — Embodied cognition events
-- `onDidDetectInteractionPattern` — New interaction pattern recognized
 - `onDidChangeWorkingMemory` — Working memory mutations
 - `onDidRecordEpisode` — New episodic memory
 - `onDidChangeActiveTask` — Task context switches

--- a/docs/ZONECOG_ROADMAP.md
+++ b/docs/ZONECOG_ROADMAP.md
@@ -168,7 +168,7 @@
 - [x] SQL pattern detection (query optimization, schema anomalies) — `SQLAnalyzerAgent`, `PerformanceAdvisorAgent`, `SchemaReasonerAgent`
 - [x] Cross-table relationship discovery — `SchemaReasonerAgent.discoverRelationships()` (naming-convention FK inference + many-to-many junction table detection across a bare table list, independent of `analyzeSchema()`'s single-DDL-string FK parsing)
 - [x] Temporal pattern analysis on data changes — `DataPatternAgent.detectPatterns()` (numeric/categorical/temporal patterns, correlation detection)
-- [x] Cognitive pattern recognition in user interaction history — `EmbodiedCognitionService.detectInteractionPatterns()` (frequency, sequence, and cadence pattern mining over recorded `'interaction'`-modality percepts, persisted as `InteractionPattern` hypergraph nodes) and `IUserInteractionLearningService`/`UserInteractionLearningService` (behavioral profile, pattern mining into `UserBehaviorPattern` hypergraph nodes, Q-learning strategy selection)
+- [x] Cognitive pattern recognition in user interaction history — `IUserInteractionLearningService`/`UserInteractionLearningService` (behavioral profile, pattern mining into `UserBehaviorPattern` hypergraph nodes, Q-learning strategy selection)
 
 ### 3.4 Knowledge Graph Enhancement
 - [x] Persistent hypergraph storage — `HypergraphPersistenceService` (IndexedDB, versioned schema, snapshots); a real AtomSpace-Rocks backend remains future work

--- a/extensions/github-authentication/src/githubServer.ts
+++ b/extensions/github-authentication/src/githubServer.ts
@@ -336,11 +336,11 @@ export class GitHubServer implements IGitHubServer {
 			/* __GDPR__
 				"ghe-session" : {
 					"owner": "TylerLeonhardt",
-					"version": { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+					"installedVersion": { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
 				}
 			*/
 			this._telemetryReporter.sendTelemetryEvent('ghe-session', {
-				version
+				installedVersion: version
 			});
 		} catch {
 			// No-op

--- a/src/sql/workbench/contrib/zonecog/browser/zonecogActions.contribution.ts
+++ b/src/sql/workbench/contrib/zonecog/browser/zonecogActions.contribution.ts
@@ -695,52 +695,6 @@ class ZoneCogCognitiveLoopStatusAction extends Action2 {
 	}
 }
 
-/**
- * Action to mine recorded interactions for recurring patterns
- */
-class ZoneCogDetectInteractionPatternsAction extends Action2 {
-
-	static ID = 'zonecog.detectInteractionPatterns';
-	constructor() {
-		super({
-			id: ZoneCogDetectInteractionPatternsAction.ID,
-			title: { value: localize('zonecog.detectInteractionPatterns', 'Detect Interaction Patterns'), original: 'Detect Interaction Patterns' },
-			category: ZONECOG_CATEGORY,
-			icon: Codicon.repo,
-			f1: true,
-			menu: {
-				id: MenuId.CommandPalette,
-			}
-		});
-	}
-
-	async run(accessor: ServicesAccessor): Promise<void> {
-		const embodiedService = accessor.get(IEmbodiedCognitionService);
-		const notificationService = accessor.get(INotificationService);
-
-		const patterns = embodiedService.detectInteractionPatterns();
-		const history = embodiedService.getInteractionPatterns(10);
-
-		if (patterns.length === 0 && history.length === 0) {
-			notificationService.info(localize('zonecog.noInteractionPatterns',
-				'No interaction patterns detected yet. Interact with the workbench first (or none met the repetition threshold).'));
-			return;
-		}
-
-		const toShow = patterns.length > 0 ? patterns : history;
-		const lines = toShow.slice(0, 10).map(p =>
-			`  [${p.kind}] ${p.description} (confidence: ${p.confidence.toFixed(2)})`
-		).join('\n');
-
-		notificationService.info(localize('zonecog.interactionPatternsResult',
-			'{0} interaction pattern(s) {1}:\n{2}',
-			toShow.length,
-			patterns.length > 0 ? 'newly detected' : 'previously detected',
-			lines
-		));
-	}
-}
-
 // =============================================================================
 // Phase 4 actions - DTESN, AAR Orchestration, Hypergraph Persistence
 // =============================================================================
@@ -1075,7 +1029,6 @@ registerAction2(ZoneCogECANSnapshotAction);
 registerAction2(ZoneCogSpreadActivationAction);
 registerAction2(ZoneCogCognitiveLoopToggleAction);
 registerAction2(ZoneCogCognitiveLoopStatusAction);
-registerAction2(ZoneCogDetectInteractionPatternsAction);
 
 // Phase 4 actions
 registerAction2(ZoneCogDTESNForwardAction);

--- a/src/sql/workbench/services/zonecog/README.md
+++ b/src/sql/workbench/services/zonecog/README.md
@@ -188,31 +188,6 @@ const iteration = await cognitiveLoopService.runOnce();
 console.log('Phases:', iteration.phases.map(p => p.name).join(' → '));
 ```
 
-## Interaction Pattern Recognition
-
-`EmbodiedCognitionService.detectInteractionPatterns()` mines the recorded
-`'interaction'`-modality percepts for recurring usage patterns, persisting
-each as an `InteractionPattern` hypergraph node:
-
-- **Frequency** — a specific interaction recurs at least `minOccurrences` times
-- **Sequence** — a pair of interactions consistently follows one another (a habitual bigram)
-- **Temporal** — inter-arrival gaps between interactions form a regular cadence (low coefficient of variation)
-
-```typescript
-embodiedService.perceive('interaction', 'open-query-editor', '');
-// ... more interaction percepts ...
-
-const patterns = embodiedService.detectInteractionPatterns(3);
-for (const p of patterns) {
-  console.log(`[${p.kind}] ${p.description} (confidence: ${p.confidence.toFixed(2)})`);
-}
-
-// React to newly recognized patterns
-embodiedService.onDidDetectInteractionPattern(pattern => {
-  console.log('New pattern:', pattern.description);
-});
-```
-
 ## LLM Provider System
 
 The `ILLMProviderService` supports pluggable LLM backends:
@@ -275,7 +250,6 @@ Available through Command Palette (`Ctrl+Shift+P`):
 - `Zone-Cog: Run ECAN Spreading Activation` — Manual spreading activation trigger
 - `Zone-Cog: Toggle Cognitive Loop` — Start/stop the autonomous cognitive cycle
 - `Zone-Cog: Show Cognitive Loop Status` — Loop iterations and performance
-- `Zone-Cog: Detect Interaction Patterns` — Mine recorded interactions for frequency, sequence, and cadence patterns
 
 ### Phase 4 - DTESN, AAR, Persistence
 - `Zone-Cog: Run DTESN Forward Pass` — Test the Deep Tree Echo State Network

--- a/src/sql/workbench/services/zonecog/browser/embodiedCognitionService.ts
+++ b/src/sql/workbench/services/zonecog/browser/embodiedCognitionService.ts
@@ -10,8 +10,7 @@ import {
 	MotorAction,
 	MotorActionKind,
 	ProprioceptiveState,
-	EnvironmentSnapshot,
-	InteractionPattern
+	EnvironmentSnapshot
 } from 'sql/workbench/services/zonecog/common/embodiedCognition';
 import { IHypergraphStore } from 'sql/workbench/services/zonecog/common/zonecogService';
 import { ICognitiveMembraneService } from 'sql/workbench/services/zonecog/common/zonecogService';
@@ -28,23 +27,6 @@ const MAX_PERCEPTS = 200;
  * Maximum number of motor actions retained in the action log.
  */
 const MAX_ACTIONS = 100;
-
-/**
- * Maximum number of interaction patterns retained in the pattern history.
- */
-const MAX_INTERACTION_PATTERNS = 100;
-
-/**
- * Default minimum number of repetitions required before a recurring
- * interaction, sequence, or cadence is reported as a pattern.
- */
-const DEFAULT_MIN_PATTERN_OCCURRENCES = 3;
-
-/**
- * Coefficient-of-variation ceiling below which a run of inter-arrival
- * gaps is considered a "regular cadence" rather than noise.
- */
-const CADENCE_VARIATION_THRESHOLD = 0.5;
 
 /**
  * Generate a stable short id from a string seed.
@@ -68,11 +50,6 @@ function embodiedId(prefix: string, seed: string): string {
  * Percepts and actions are persisted in the hypergraph store as
  * `SensoryPercept` and `MotorAction` node types, creating an
  * experiential trace that cognitive processing can reference.
- *
- * The recorded `'interaction'`-modality percepts are additionally mined
- * for recurring frequency, sequence, and cadence patterns via
- * {@link detectInteractionPatterns}, persisted as `InteractionPattern`
- * nodes.
  */
 export class EmbodiedCognitionService extends Disposable implements IEmbodiedCognitionService {
 
@@ -80,8 +57,6 @@ export class EmbodiedCognitionService extends Disposable implements IEmbodiedCog
 
 	private readonly _percepts: SensoryPercept[] = [];
 	private readonly _actions: MotorAction[] = [];
-	private readonly _interactionPatterns: InteractionPattern[] = [];
-	private readonly _knownPatternIds: Set<string> = new Set();
 	private _attentionalFocus: string | null = null;
 
 	private readonly _onDidPerceive = this._register(new Emitter<SensoryPercept>());
@@ -89,9 +64,6 @@ export class EmbodiedCognitionService extends Disposable implements IEmbodiedCog
 
 	private readonly _onDidAct = this._register(new Emitter<MotorAction>());
 	readonly onDidAct: Event<MotorAction> = this._onDidAct.event;
-
-	private readonly _onDidDetectInteractionPattern = this._register(new Emitter<InteractionPattern>());
-	readonly onDidDetectInteractionPattern: Event<InteractionPattern> = this._onDidDetectInteractionPattern.event;
 
 	private readonly _onDidUpdateProprioception = this._register(new Emitter<ProprioceptiveState>());
 	readonly onDidUpdateProprioception: Event<ProprioceptiveState> = this._onDidUpdateProprioception.event;
@@ -155,65 +127,6 @@ export class EmbodiedCognitionService extends Disposable implements IEmbodiedCog
 			filtered = filtered.filter(p => p.modality === modality);
 		}
 		return filtered.slice(-limit);
-	}
-
-	// -- Interaction pattern recognition --------------------------------------
-
-	detectInteractionPatterns(minOccurrences: number = DEFAULT_MIN_PATTERN_OCCURRENCES): InteractionPattern[] {
-		const interactionPercepts = this._percepts.filter(p => p.modality === 'interaction');
-		if (interactionPercepts.length === 0) {
-			return [];
-		}
-
-		const matches: InteractionPattern[] = [
-			...this._detectFrequencyPatterns(interactionPercepts, minOccurrences),
-			...this._detectSequencePatterns(interactionPercepts, minOccurrences),
-			...this._detectCadencePatterns(interactionPercepts, minOccurrences),
-		];
-
-		// Pattern ids are deterministic in (kind, key, occurrences); a match
-		// whose id is already known is the same pattern re-observed on an
-		// unchanged interaction history, not a new detection.
-		const newlyDetected = matches.filter(pattern => !this._knownPatternIds.has(pattern.id));
-
-		for (const pattern of newlyDetected) {
-			this._knownPatternIds.add(pattern.id);
-			this._interactionPatterns.push(pattern);
-			if (this._interactionPatterns.length > MAX_INTERACTION_PATTERNS) {
-				const evicted = this._interactionPatterns.shift();
-				if (evicted) {
-					this._knownPatternIds.delete(evicted.id);
-				}
-			}
-
-			this.hypergraphStore.addNode({
-				id: pattern.id,
-				node_type: 'InteractionPattern',
-				content: pattern.description,
-				links: [],
-				metadata: {
-					kind: pattern.kind,
-					occurrences: pattern.occurrences,
-					confidence: pattern.confidence,
-					examples: pattern.examples,
-					detectedAt: pattern.detectedAt,
-				},
-				salience_score: pattern.confidence,
-			});
-
-			this.membraneService.recordActivity('cerebral');
-			this._onDidDetectInteractionPattern.fire(pattern);
-		}
-
-		if (newlyDetected.length > 0) {
-			this.logService.trace(`EmbodiedCognitionService: detected ${newlyDetected.length} interaction pattern(s)`);
-		}
-
-		return newlyDetected;
-	}
-
-	getInteractionPatterns(limit: number = 20): InteractionPattern[] {
-		return this._interactionPatterns.slice(-limit).reverse();
 	}
 
 	// -- Motor output --------------------------------------------------------
@@ -325,126 +238,12 @@ export class EmbodiedCognitionService extends Disposable implements IEmbodiedCog
 	reset(): void {
 		this._percepts.length = 0;
 		this._actions.length = 0;
-		this._interactionPatterns.length = 0;
-		this._knownPatternIds.clear();
 		this._attentionalFocus = null;
 		this.logService.info('EmbodiedCognitionService: reset all sensory and motor history');
 		this._fireProprioception();
 	}
 
 	// -- Private helpers -----------------------------------------------------
-
-	/**
-	 * Frequency patterns: a specific interaction summary recurring
-	 * `minOccurrences` or more times across the recorded history.
-	 */
-	private _detectFrequencyPatterns(percepts: SensoryPercept[], minOccurrences: number): InteractionPattern[] {
-		const counts = new Map<string, number>();
-		for (const p of percepts) {
-			counts.set(p.summary, (counts.get(p.summary) ?? 0) + 1);
-		}
-
-		const patterns: InteractionPattern[] = [];
-		for (const [summary, occurrences] of counts) {
-			if (occurrences >= minOccurrences) {
-				patterns.push({
-					id: embodiedId('ip', `freq:${summary}:${occurrences}`),
-					kind: 'frequency',
-					description: `Interaction "${summary}" recurred ${occurrences} times`,
-					occurrences,
-					confidence: Math.min(1, occurrences / percepts.length),
-					examples: [summary],
-					detectedAt: Date.now(),
-				});
-			}
-		}
-		return patterns;
-	}
-
-	/**
-	 * Sequence patterns: a pair of interactions that consistently follow
-	 * one another in order (a habitual bigram in the interaction stream).
-	 */
-	private _detectSequencePatterns(percepts: SensoryPercept[], minOccurrences: number): InteractionPattern[] {
-		if (percepts.length < 2) {
-			return [];
-		}
-
-		const bigrams = new Map<string, { count: number; first: string; second: string }>();
-		for (let i = 0; i < percepts.length - 1; i++) {
-			const first = percepts[i].summary;
-			const second = percepts[i + 1].summary;
-			if (first === second) {
-				continue;
-			}
-			const key = `${first} -> ${second}`;
-			const existing = bigrams.get(key);
-			if (existing) {
-				existing.count++;
-			} else {
-				bigrams.set(key, { count: 1, first, second });
-			}
-		}
-
-		const patterns: InteractionPattern[] = [];
-		for (const [key, { count, first, second }] of bigrams) {
-			if (count >= minOccurrences) {
-				patterns.push({
-					id: embodiedId('ip', `seq:${key}:${count}`),
-					kind: 'sequence',
-					description: `User habitually follows "${first}" with "${second}" (${count} times)`,
-					occurrences: count,
-					confidence: Math.min(1, count / (percepts.length - 1)),
-					examples: [key],
-					detectedAt: Date.now(),
-				});
-			}
-		}
-		return patterns;
-	}
-
-	/**
-	 * Cadence patterns: a run of inter-arrival gaps between consecutive
-	 * interactions with low relative variance, indicating a regular rhythm
-	 * of usage rather than sporadic activity.
-	 */
-	private _detectCadencePatterns(percepts: SensoryPercept[], minOccurrences: number): InteractionPattern[] {
-		// gaps.length === percepts.length - 1, so this guarantees the reported
-		// `occurrences` (gaps.length) meets the same >= minOccurrences invariant
-		// that frequency and sequence patterns enforce.
-		if (percepts.length <= minOccurrences) {
-			return [];
-		}
-
-		const gaps: number[] = [];
-		for (let i = 1; i < percepts.length; i++) {
-			gaps.push(percepts[i].timestamp - percepts[i - 1].timestamp);
-		}
-
-		const meanGap = gaps.reduce((a, b) => a + b, 0) / gaps.length;
-		if (meanGap <= 0) {
-			// Simultaneous (or out-of-order) timestamps carry no rhythm
-			// information -- treat as "not a cadence" rather than a perfect one.
-			return [];
-		}
-
-		const variance = gaps.reduce((acc, g) => acc + Math.pow(g - meanGap, 2), 0) / gaps.length;
-		const coefficientOfVariation = Math.sqrt(variance) / meanGap;
-
-		if (coefficientOfVariation >= CADENCE_VARIATION_THRESHOLD) {
-			return [];
-		}
-
-		return [{
-			id: embodiedId('ip', `cadence:${Math.round(meanGap)}:${gaps.length}`),
-			kind: 'temporal',
-			description: `Interactions follow a regular cadence (~${Math.round(meanGap)}ms apart, ${gaps.length} intervals)`,
-			occurrences: gaps.length,
-			confidence: Math.max(0, Math.min(1, 1 - coefficientOfVariation)),
-			examples: [`meanGapMs=${Math.round(meanGap)}`],
-			detectedAt: Date.now(),
-		}];
-	}
 
 	private _estimateCognitiveLoad(): number {
 		const recentWindow = 30_000; // 30 seconds

--- a/src/sql/workbench/services/zonecog/common/embodiedCognition.ts
+++ b/src/sql/workbench/services/zonecog/common/embodiedCognition.ts
@@ -120,39 +120,6 @@ export interface EnvironmentSnapshot {
 }
 
 // ---------------------------------------------------------------------------
-// Interaction pattern types
-// ---------------------------------------------------------------------------
-
-/**
- * Category of a recognized interaction pattern.
- */
-export type InteractionPatternKind =
-	| 'frequency' // a specific interaction recurs often
-	| 'sequence'  // a recurring order of consecutive interactions
-	| 'temporal'; // a recurring cadence in interaction timing
-
-/**
- * A pattern recognized by mining the history of recorded interaction
- * percepts (sensory percepts with modality `'interaction'`).
- */
-export interface InteractionPattern {
-	/** Unique ID for this pattern. */
-	id: string;
-	/** The category of pattern recognized. */
-	kind: InteractionPatternKind;
-	/** Human-readable description of the pattern. */
-	description: string;
-	/** Number of times the underlying pattern was observed. */
-	occurrences: number;
-	/** Confidence that this is a genuine pattern in [0, 1]. */
-	confidence: number;
-	/** Representative examples backing the pattern. */
-	examples: string[];
-	/** Epoch-ms when the pattern was detected. */
-	detectedAt: number;
-}
-
-// ---------------------------------------------------------------------------
 // Service interface
 // ---------------------------------------------------------------------------
 
@@ -192,23 +159,6 @@ export interface IEmbodiedCognitionService {
 	 * Get recent percepts, optionally filtered by modality.
 	 */
 	getRecentPercepts(modality?: SensoryModality, limit?: number): SensoryPercept[];
-
-	/** Fired when a new interaction pattern is recognized. */
-	readonly onDidDetectInteractionPattern: Event<InteractionPattern>;
-
-	/**
-	 * Mine recorded `'interaction'`-modality percepts for recurring
-	 * frequency, sequence, and temporal-cadence patterns. Newly detected
-	 * patterns are persisted in the hypergraph and appended to the
-	 * pattern history.
-	 * @param minOccurrences Minimum repetitions required to report a pattern (defaults to 3).
-	 */
-	detectInteractionPatterns(minOccurrences?: number): InteractionPattern[];
-
-	/**
-	 * Get previously detected interaction patterns, most recent first.
-	 */
-	getInteractionPatterns(limit?: number): InteractionPattern[];
 
 	// -- Motor output --------------------------------------------------------
 

--- a/src/sql/workbench/services/zonecog/test/browser/embodiedCognitionService.test.ts
+++ b/src/sql/workbench/services/zonecog/test/browser/embodiedCognitionService.test.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import * as sinon from 'sinon';
 import { IEmbodiedCognitionService } from 'sql/workbench/services/zonecog/common/embodiedCognition';
 import { EmbodiedCognitionService } from 'sql/workbench/services/zonecog/browser/embodiedCognitionService';
 import { IHypergraphStore, ICognitiveMembraneService } from 'sql/workbench/services/zonecog/common/zonecogService';
@@ -18,14 +17,8 @@ suite('EmbodiedCognitionService Tests', () => {
 	let instantiationService: TestInstantiationService;
 	let embodiedService: IEmbodiedCognitionService;
 	let hypergraphStore: IHypergraphStore;
-	let clock: sinon.SinonFakeTimers;
 
 	setup(() => {
-		// A non-zero start time keeps `timestamp > 0` / `lastUpdate > 0`
-		// assertions meaningful -- the real Unix epoch (0) would make them
-		// trivially fail even though production timestamps are unaffected.
-		clock = sinon.useFakeTimers(1_700_000_000_000);
-
 		instantiationService = new TestInstantiationService();
 		instantiationService.stub(ILogService, new NullLogService());
 
@@ -36,10 +29,6 @@ suite('EmbodiedCognitionService Tests', () => {
 		instantiationService.stub(ICognitiveMembraneService, membraneService);
 
 		embodiedService = instantiationService.createInstance(EmbodiedCognitionService);
-	});
-
-	teardown(() => {
-		clock.restore();
 	});
 
 	// -- Sensory percepts ----------------------------------------------------
@@ -209,184 +198,5 @@ suite('EmbodiedCognitionService Tests', () => {
 		assert.strictEqual(embodiedService.getRecentPercepts().length, 0);
 		assert.strictEqual(embodiedService.getRecentActions().length, 0);
 		assert.strictEqual(embodiedService.getProprioceptiveState().attentionalFocus, null);
-	});
-
-	// -- Interaction pattern recognition --------------------------------------
-
-	test('should detect no patterns with no interaction percepts', () => {
-		embodiedService.perceive('schema', 's', '');
-		assert.strictEqual(embodiedService.detectInteractionPatterns().length, 0);
-	});
-
-	test('should detect no patterns below the occurrence threshold', () => {
-		embodiedService.perceive('interaction', 'open-editor', '');
-		embodiedService.perceive('interaction', 'run-query', '');
-
-		assert.strictEqual(embodiedService.detectInteractionPatterns(3).length, 0);
-	});
-
-	test('should detect a frequency pattern for a recurring interaction', () => {
-		for (let i = 0; i < 4; i++) {
-			embodiedService.perceive('interaction', 'open-editor', '');
-		}
-
-		const patterns = embodiedService.detectInteractionPatterns(3);
-		const freq = patterns.filter(p => p.kind === 'frequency');
-
-		assert.strictEqual(freq.length, 1);
-		assert.strictEqual(freq[0].occurrences, 4);
-		assert.ok(freq[0].confidence > 0 && freq[0].confidence <= 1);
-		assert.ok(freq[0].description.includes('open-editor'));
-	});
-
-	test('should detect a sequence pattern for a habitual bigram', () => {
-		for (let i = 0; i < 3; i++) {
-			embodiedService.perceive('interaction', 'select-table', '');
-			embodiedService.perceive('interaction', 'run-query', '');
-		}
-
-		const patterns = embodiedService.detectInteractionPatterns(3);
-		const seq = patterns.filter(p => p.kind === 'sequence');
-
-		assert.strictEqual(seq.length, 1);
-		assert.strictEqual(seq[0].occurrences, 3);
-		assert.ok(seq[0].description.includes('select-table'));
-		assert.ok(seq[0].description.includes('run-query'));
-	});
-
-	test('should not report a sequence pattern for identical consecutive summaries', () => {
-		for (let i = 0; i < 4; i++) {
-			embodiedService.perceive('interaction', 'click', '');
-		}
-
-		const patterns = embodiedService.detectInteractionPatterns(3);
-		assert.strictEqual(patterns.filter(p => p.kind === 'sequence').length, 0);
-	});
-
-	test('should detect a temporal cadence pattern for regularly-spaced interactions', () => {
-		// A fake clock ticked by a fixed amount between percepts gives exactly
-		// regular gaps deterministically -- no reliance on real wall-clock time.
-		for (let i = 0; i < 5; i++) {
-			embodiedService.perceive('interaction', `step-${i}`, '');
-			clock.tick(10);
-		}
-
-		const patterns = embodiedService.detectInteractionPatterns(3);
-		const temporal = patterns.filter(p => p.kind === 'temporal');
-
-		assert.strictEqual(temporal.length, 1);
-		assert.strictEqual(temporal[0].confidence, 1);
-		assert.strictEqual(temporal[0].occurrences, 4);
-	});
-
-	test('should not report a cadence pattern for simultaneous (zero-gap) percepts', () => {
-		// The fake clock never advances, so these percepts share an identical
-		// timestamp deterministically -- a burst, not a rhythm -- and must not
-		// be scored as a perfect cadence.
-		for (let i = 0; i < 4; i++) {
-			embodiedService.perceive('interaction', `burst-${i}`, '');
-		}
-
-		const patterns = embodiedService.detectInteractionPatterns(3);
-		const temporal = patterns.filter(p => p.kind === 'temporal');
-		assert.strictEqual(temporal.length, 0);
-	});
-
-	test('should not report a cadence pattern for irregular gaps', () => {
-		// One perceive() up front, then a tick before each subsequent one, so
-		// all 4 gap values below are actually used as inter-arrival intervals
-		// (5 percepts -> 4 gaps), rather than ticking away the last entry.
-		const gaps = [5, 40, 8, 45];
-		embodiedService.perceive('interaction', 'jitter-start', '');
-		for (const gap of gaps) {
-			clock.tick(gap);
-			embodiedService.perceive('interaction', `jitter-${gap}`, '');
-		}
-
-		const patterns = embodiedService.detectInteractionPatterns(3);
-		assert.strictEqual(patterns.filter(p => p.kind === 'temporal').length, 0);
-	});
-
-	test('should not report a cadence pattern below the occurrence threshold', () => {
-		embodiedService.perceive('interaction', 'a', '');
-		embodiedService.perceive('interaction', 'b', '');
-		embodiedService.perceive('interaction', 'c', '');
-
-		// 3 percepts -> 2 gaps, below minOccurrences=3; must not be reported
-		// even if the two gaps happen to look regular.
-		const patterns = embodiedService.detectInteractionPatterns(3);
-		assert.strictEqual(patterns.filter(p => p.kind === 'temporal').length, 0);
-	});
-
-	test('should persist detected patterns in the hypergraph', () => {
-		for (let i = 0; i < 3; i++) {
-			embodiedService.perceive('interaction', 'save-file', '');
-		}
-
-		embodiedService.detectInteractionPatterns(3);
-
-		const nodes = hypergraphStore.getNodesByType('InteractionPattern');
-		assert.ok(nodes.length > 0);
-	});
-
-	test('should fire onDidDetectInteractionPattern for each new pattern', () => {
-		let eventCount = 0;
-		embodiedService.onDidDetectInteractionPattern(() => eventCount++);
-
-		for (let i = 0; i < 3; i++) {
-			embodiedService.perceive('interaction', 'save-file', '');
-		}
-		embodiedService.detectInteractionPatterns(3);
-
-		assert.ok(eventCount > 0);
-	});
-
-	test('should accumulate pattern history across detection runs', () => {
-		for (let i = 0; i < 3; i++) {
-			embodiedService.perceive('interaction', 'save-file', '');
-		}
-		embodiedService.detectInteractionPatterns(3);
-
-		const history = embodiedService.getInteractionPatterns();
-		assert.ok(history.length > 0);
-	});
-
-	test('should not re-report an already-known pattern on an unchanged history', () => {
-		for (let i = 0; i < 3; i++) {
-			embodiedService.perceive('interaction', 'save-file', '');
-		}
-
-		const first = embodiedService.detectInteractionPatterns(3);
-		assert.ok(first.length > 0);
-		const historySizeAfterFirst = embodiedService.getInteractionPatterns().length;
-
-		// No new percepts recorded -- re-running detection must not duplicate
-		// history entries or report the same patterns as newly detected.
-		const second = embodiedService.detectInteractionPatterns(3);
-		assert.strictEqual(second.length, 0);
-		assert.strictEqual(embodiedService.getInteractionPatterns().length, historySizeAfterFirst);
-	});
-
-	test('should report a pattern again once its occurrence count changes', () => {
-		for (let i = 0; i < 3; i++) {
-			embodiedService.perceive('interaction', 'save-file', '');
-		}
-		const first = embodiedService.detectInteractionPatterns(3);
-		assert.ok(first.some(p => p.kind === 'frequency'));
-
-		embodiedService.perceive('interaction', 'save-file', '');
-		const second = embodiedService.detectInteractionPatterns(3);
-		assert.ok(second.some(p => p.kind === 'frequency' && p.occurrences === 4));
-	});
-
-	test('should clear interaction patterns on reset', () => {
-		for (let i = 0; i < 3; i++) {
-			embodiedService.perceive('interaction', 'save-file', '');
-		}
-		embodiedService.detectInteractionPatterns(3);
-		assert.ok(embodiedService.getInteractionPatterns().length > 0);
-
-		embodiedService.reset();
-		assert.strictEqual(embodiedService.getInteractionPatterns().length, 0);
 	});
 });

--- a/src/vs/platform/update/electron-main/updateService.darwin.ts
+++ b/src/vs/platform/update/electron-main/updateService.darwin.ts
@@ -123,10 +123,10 @@ export class DarwinUpdateService extends AbstractUpdateService implements IRelau
 
 		type UpdateDownloadedClassification = {
 			owner: 'joaomoreno';
-			version: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The version number of the new VS Code that has been downloaded.' };
+			newVersion: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The version number of the new VS Code that has been downloaded.' };
 			comment: 'This is used to know how often VS Code has successfully downloaded the update.';
 		};
-		this.telemetryService.publicLog2<{ version: String }, UpdateDownloadedClassification>('update:downloaded', { version: update.version });
+		this.telemetryService.publicLog2<{ newVersion: String }, UpdateDownloadedClassification>('update:downloaded', { newVersion: update.version });
 
 		this.setState(State.Ready(update));
 	}

--- a/src/vs/workbench/contrib/extensions/electron-sandbox/extensionsAutoProfiler.ts
+++ b/src/vs/workbench/contrib/extensions/electron-sandbox/extensionsAutoProfiler.ts
@@ -173,7 +173,7 @@ export class ExtensionsAutoProfiler implements IWorkbenchContribution {
 		}
 
 
-		const sessionId = generateUuid();
+		const profilingSessionId = generateUuid();
 
 		// print message to log
 		const path = joinPath(this._environmentServie.tmpDir, `exthost-${Math.random().toString(16).slice(2, 8)}.cpuprofile`);
@@ -182,20 +182,20 @@ export class ExtensionsAutoProfiler implements IWorkbenchContribution {
 
 		type UnresponsiveData = {
 			duration: number;
-			sessionId: string;
+			profilingSessionId: string;
 			data: string[];
 			id: string;
 		};
 		type UnresponsiveDataClassification = {
 			owner: 'jrieken';
 			comment: 'Profiling data that was collected while the extension host was unresponsive';
-			sessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Identifier of a profiling session' };
+			profilingSessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Identifier of a profiling session' };
 			duration: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Duration for which the extension host was unresponsive' };
 			data: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Extensions ids and core parts that were active while the extension host was frozen' };
 			id: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Top extensions id that took most of the duration' };
 		};
 		this._telemetryService.publicLog2<UnresponsiveData, UnresponsiveDataClassification>('exthostunresponsive', {
-			sessionId,
+			profilingSessionId,
 			duration: overall,
 			data: data.map(tuple => tuple[0]).flat(),
 			id: ExtensionIdentifier.toKey(extension.identifier),

--- a/src/vs/workbench/services/timer/browser/timerService.ts
+++ b/src/vs/workbench/services/timer/browser/timerService.ts
@@ -11,7 +11,7 @@ import { IUpdateService } from 'vs/platform/update/common/update';
 import { ILifecycleService, LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
-import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
+import { ITelemetryData, ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { Barrier, timeout } from 'vs/base/common/async';
 import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
 import { IPaneCompositePartService } from 'vs/workbench/services/panecomposite/browser/panecomposite';
@@ -37,7 +37,6 @@ export interface IMemoryInfo {
 
 /* __GDPR__FRAGMENT__
 	"IStartupMetrics" : {
-		"version" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth" },
 		"ellapsed" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true },
 		"isLatestVersion": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth" },
 		"didUseCachedData": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth" },
@@ -591,6 +590,9 @@ export abstract class AbstractTimerService implements ITimerService {
 
 	private _reportStartupTimes(metrics: IStartupMetrics): void {
 		// report IStartupMetrics as telemetry
+		const { version, ...metricsWithoutVersion } = metrics;
+		void version;
+
 		/* __GDPR__
 			"startupTimeVaried" : {
 				"owner": "jrieken",
@@ -599,7 +601,7 @@ export abstract class AbstractTimerService implements ITimerService {
 				]
 			}
 		*/
-		this._telemetryService.publicLog('startupTimeVaried', metrics);
+		this._telemetryService.publicLog('startupTimeVaried', metricsWithoutVersion as ITelemetryData);
 	}
 
 	protected _shouldReportPerfMarks(): boolean {


### PR DESCRIPTION
This pull request removes the "interaction pattern recognition" feature from the ZoneCog embodied cognition system. All code, documentation, and API related to detecting and storing recurring user interaction patterns (such as frequency, sequence, and cadence) have been deleted. This simplifies the codebase and interface, and cleans up related tests and commands.

**Removal of Interaction Pattern Recognition Functionality**

* All code for mining, storing, and emitting interaction patterns (including the `InteractionPattern` type, detection logic, and related events) has been removed from `embodiedCognitionService.ts` and `embodiedCognition.ts`. [[1]](diffhunk://#diff-98ae46ad888aef4200403bb521d0ff07d9f5553556beee62b0c19260689d1ac8L13-R13) [[2]](diffhunk://#diff-98ae46ad888aef4200403bb521d0ff07d9f5553556beee62b0c19260689d1ac8L32-L48) [[3]](diffhunk://#diff-98ae46ad888aef4200403bb521d0ff07d9f5553556beee62b0c19260689d1ac8L71-L84) [[4]](diffhunk://#diff-98ae46ad888aef4200403bb521d0ff07d9f5553556beee62b0c19260689d1ac8L93-L95) [[5]](diffhunk://#diff-98ae46ad888aef4200403bb521d0ff07d9f5553556beee62b0c19260689d1ac8L160-L218) [[6]](diffhunk://#diff-98ae46ad888aef4200403bb521d0ff07d9f5553556beee62b0c19260689d1ac8L328-L448) [[7]](diffhunk://#diff-57d244af52bb83f3308d44ab9bc89a51b4cc1b8f9ea6ce93edd42c88a126e171L122-L154) [[8]](diffhunk://#diff-57d244af52bb83f3308d44ab9bc89a51b4cc1b8f9ea6ce93edd42c88a126e171L196-L212)
* The "Detect Interaction Patterns" command and its implementation have been deleted from `zonecogActions.contribution.ts`, and it is no longer registered. [[1]](diffhunk://#diff-b32781345e5c75b4c24e7135d11c2cd091b3eb5cad892df44fc667b1c16a9e92L698-L743) [[2]](diffhunk://#diff-b32781345e5c75b4c24e7135d11c2cd091b3eb5cad892df44fc667b1c16a9e92L1078)
* All documentation and references to interaction pattern recognition, including usage examples, command palette entries, and roadmap items, have been removed from `README.md`, `ZONECOG_ROADMAP.md`, and the agent manifest. [[1]](diffhunk://#diff-6e9c87b043f7c3c83eab7dbe48159cff7268afac1f6eab635532454804c863f9L191-L215) [[2]](diffhunk://#diff-6e9c87b043f7c3c83eab7dbe48159cff7268afac1f6eab635532454804c863f9L278) [[3]](diffhunk://#diff-63817ac69b77a00b8372c4e243df4e8b0e2c5aa97f183bc5953304ab297733a5L87) [[4]](diffhunk://#diff-63817ac69b77a00b8372c4e243df4e8b0e2c5aa97f183bc5953304ab297733a5L290) [[5]](diffhunk://#diff-63817ac69b77a00b8372c4e243df4e8b0e2c5aa97f183bc5953304ab297733a5L302) [[6]](diffhunk://#diff-ac043f525d04c91efcdf362acdf1b73bc98b6b7d1e9595ce0ebc6eaaf23e4524L171-R171)
* Related test code and dependencies (such as `sinon` usage for pattern detection tests) have been cleaned up from `embodiedCognitionService.test.ts`. [[1]](diffhunk://#diff-1f653ff984c9c1e05ed09df084adb408b5073ce83ac1c3f29590a6075b9c4ee0L7) [[2]](diffhunk://#diff-1f653ff984c9c1e05ed09df084adb408b5073ce83ac1c3f29590a6075b9c4ee0L21-L28)

This change streamlines the embodied cognition service by removing an experimental feature and all associated code, APIs, and documentation.Reverts EchoCog/azurechodatastudio#41