### PR TITLE
feat(zonecog): add PLN-style forward-chaining inference (URE-lite)

### DIFF
--- a/docs/ZONECOG_ROADMAP.md
+++ b/docs/ZONECOG_ROADMAP.md
@@ -2,7 +2,7 @@
 
 **Ticket**: ECH-4  
 **Status**: Active  
-**Last Updated**: 2026-07-16
+**Last Updated**: 2026-07-19
 
 ## Phase Overview
 
@@ -160,8 +160,8 @@
 
 ### 3.2 AtomSpace Reasoning
 - [ ] Real AtomSpace transport (there is no mock adapter to replace — `HypergraphStore` is a from-scratch in-memory store; a real transport is new work)
-- [ ] PLN (Probabilistic Logic Networks) integration for rule-based reasoning
-- [ ] URE (Unified Rule Engine) for inference chains
+- [x] PLN (Probabilistic Logic Networks) integration for rule-based reasoning — `IPLNReasoningService`/`PLNReasoningService` (strength/confidence truth values on hypergraph links, PLN deduction formula using node salience as a prior)
+- [x] URE (Unified Rule Engine) for inference chains — `PLNReasoningService.infer()` (forward-chaining deduction/inversion/similarity rules over binary directed links, iterated to a fixed point or `maxIterations`, conclusions persisted as `Inferred` hypergraph links that feed later chaining rounds)
 - [x] ECAN (Economic Attention Networks) for salience-based focus — `IECANAttentionService`/`ECANAttentionService` (spreading activation, rent collection, attentional focus)
 
 ### 3.3 Pattern Mining

--- a/src/sql/workbench/contrib/zonecog/browser/zonecogActions.contribution.ts
+++ b/src/sql/workbench/contrib/zonecog/browser/zonecogActions.contribution.ts
@@ -28,6 +28,7 @@ import { CognitiveLoopStatusBarContribution } from 'sql/workbench/contrib/zoneco
 import { IAgiStudioService } from 'sql/workbench/services/zonecog/common/agiStudio';
 import { ICognitiveProvenanceService } from 'sql/workbench/services/zonecog/common/cognitiveProvenance';
 import { ISchemaEvolutionService } from 'sql/workbench/services/zonecog/common/schemaEvolution';
+import { IPLNReasoningService } from 'sql/workbench/services/zonecog/common/plnReasoning';
 
 const ZONECOG_CATEGORY = { value: localize('zonecog.category', 'Zone-Cog'), original: 'Zone-Cog' };
 
@@ -1865,6 +1866,54 @@ class ZoneCogSchemaEvolutionAction extends Action2 {
 // Phase 3.4 actions
 registerAction2(ZoneCogAuditTrailAction);
 registerAction2(ZoneCogSchemaEvolutionAction);
+
+// ============================================================================
+// Phase 3.2 Action: PLN Reasoning
+// ============================================================================
+
+/**
+ * Action to run PLN-style forward-chaining inference over the hypergraph
+ */
+class ZoneCogRunInferenceAction extends Action2 {
+
+	static ID = 'zonecog.runInference';
+	constructor() {
+		super({
+			id: ZoneCogRunInferenceAction.ID,
+			title: { value: localize('zonecog.runInference', 'Run PLN Inference'), original: 'Run PLN Inference' },
+			category: ZONECOG_CATEGORY,
+			icon: Codicon.beaker,
+			f1: true,
+			menu: { id: MenuId.CommandPalette },
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const plnService = accessor.get(IPLNReasoningService);
+		const notificationService = accessor.get(INotificationService);
+
+		const result = plnService.infer();
+		if (result.inferred.length === 0) {
+			notificationService.info(localize('zonecog.runInferenceEmpty',
+				'PLN Inference: examined {0} link(s) over {1} iteration(s), no new conclusions derived (total inferred so far: {2}).',
+				result.linksExamined, result.iterations, plnService.getInferredLinks().length));
+			return;
+		}
+
+		const top = result.inferred
+			.slice()
+			.sort((a, b) => b.truthValue.confidence - a.truthValue.confidence)
+			.slice(0, 5)
+			.map(l => `  ${l.from} -> ${l.to} [${l.rule}] (strength ${l.truthValue.strength.toFixed(2)}, confidence ${l.truthValue.confidence.toFixed(2)})`)
+			.join('\n');
+
+		notificationService.info(localize('zonecog.runInferenceInfo',
+			'PLN Inference: derived {0} new link(s) over {1} iteration(s) from {2} examined link(s).\nTop conclusions:\n{3}',
+			result.inferred.length, result.iterations, result.linksExamined, top));
+	}
+}
+
+registerAction2(ZoneCogRunInferenceAction);
 
 // Register the cognitive loop status bar contribution so the loop state is
 // always visible in the workbench status bar.

--- a/src/sql/workbench/services/zonecog/browser/plnReasoningService.ts
+++ b/src/sql/workbench/services/zonecog/browser/plnReasoningService.ts
@@ -1,0 +1,292 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import {
+	IPLNReasoningService,
+	TruthValue,
+	InferredLink,
+	InferenceRunResult,
+	InferenceOptions
+} from 'sql/workbench/services/zonecog/common/plnReasoning';
+import { IHypergraphStore, ICognitiveMembraneService, HypergraphLink } from 'sql/workbench/services/zonecog/common/zonecogService';
+import { Disposable } from 'vs/base/common/lifecycle';
+import { Emitter, Event } from 'vs/base/common/event';
+import { ILogService } from 'vs/platform/log/common/log';
+
+const INFERRED_LINK_TYPE = 'Inferred';
+
+const DEFAULT_LINK_STRENGTH = 0.9;
+const DEFAULT_LINK_CONFIDENCE = 0.5;
+
+const DEDUCTION_CONFIDENCE_DISCOUNT = 0.9;
+const INVERSION_CONFIDENCE_DISCOUNT = 0.8;
+const SIMILARITY_CONFIDENCE_DISCOUNT = 0.85;
+
+const DEFAULT_MAX_ITERATIONS = 3;
+const DEFAULT_MIN_CONFIDENCE = 0.05;
+
+/** Safety cap on total inferred links retained, to bound runaway forward-chaining. */
+const MAX_INFERRED_LINKS = 1000;
+
+function clamp01(n: number): number {
+	if (Number.isNaN(n)) { return 0; }
+	return Math.max(0, Math.min(1, n));
+}
+
+/** A directed binary edge extracted from a hypergraph link's `outgoing` list. */
+interface DirectedEdge {
+	linkId: string;
+	from: string;
+	to: string;
+	truthValue: TruthValue;
+}
+
+/**
+ * Implementation of the PLN reasoning service - a lightweight forward-chaining
+ * Unified Rule Engine (URE) over the hypergraph store's binary directed links.
+ *
+ * Only links whose `outgoing` list has exactly two entries are treated as
+ * binary relations `outgoing[0] -> outgoing[1]`; hyperedges with other
+ * arities are ignored by the reasoner. Node `salience_score` is used as a
+ * proxy for prior probability in the PLN deduction formula.
+ */
+export class PLNReasoningService extends Disposable implements IPLNReasoningService {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _truthValues = new Map<string, TruthValue>();
+	private readonly _inferred = new Map<string, InferredLink>();
+	/** Dedup key `${rule}|${from}|${to}` -> already-derived inferred link id. */
+	private readonly _inferredIndex = new Map<string, string>();
+	private _inferenceCounter = 0;
+
+	private readonly _onDidInferLink = this._register(new Emitter<InferredLink>());
+	readonly onDidInferLink: Event<InferredLink> = this._onDidInferLink.event;
+
+	constructor(
+		@ILogService private readonly logService: ILogService,
+		@IHypergraphStore private readonly hypergraphStore: IHypergraphStore,
+		@ICognitiveMembraneService private readonly membraneService: ICognitiveMembraneService
+	) {
+		super();
+		this.logService.info('PLNReasoningService: initialized PLN/URE-lite forward-chaining reasoner');
+	}
+
+	// -- Truth values ------------------------------------------------------------------
+
+	setTruthValue(linkId: string, truthValue: TruthValue): void {
+		this._truthValues.set(linkId, {
+			strength: clamp01(truthValue.strength),
+			confidence: clamp01(truthValue.confidence)
+		});
+	}
+
+	getTruthValue(linkId: string): TruthValue | undefined {
+		return this._truthValues.get(linkId);
+	}
+
+	private _truthValueOf(linkId: string): TruthValue {
+		return this._truthValues.get(linkId) ?? { strength: DEFAULT_LINK_STRENGTH, confidence: DEFAULT_LINK_CONFIDENCE };
+	}
+
+	// -- Inference -----------------------------------------------------------------------
+
+	infer(options?: InferenceOptions): InferenceRunResult {
+		this.membraneService.recordActivity('cerebral');
+
+		const maxIterations = options?.maxIterations ?? DEFAULT_MAX_ITERATIONS;
+		const minConfidence = options?.minConfidence ?? DEFAULT_MIN_CONFIDENCE;
+
+		const newlyInferred: InferredLink[] = [];
+		let iterations = 0;
+		let linksExamined = 0;
+
+		for (let i = 0; i < maxIterations; i++) {
+			iterations++;
+			const edges = this._collectDirectedEdges();
+			linksExamined = Math.max(linksExamined, edges.length);
+
+			const candidates = [
+				...this._applyDeduction(edges),
+				...this._applyInversion(edges),
+				...this._applySimilarity(edges)
+			];
+
+			let producedThisRound = 0;
+			for (const candidate of candidates) {
+				if (this._inferred.size >= MAX_INFERRED_LINKS) {
+					this.logService.warn('PLNReasoningService: reached max inferred link cap, stopping early');
+					break;
+				}
+				if (candidate.truthValue.confidence < minConfidence) {
+					continue;
+				}
+				const dedupKey = `${candidate.rule}|${candidate.from}|${candidate.to}`;
+				if (this._inferredIndex.has(dedupKey)) {
+					continue;
+				}
+				const persisted = this._persistInference(candidate);
+				this._inferredIndex.set(dedupKey, persisted.id);
+				this._inferred.set(persisted.id, persisted);
+				newlyInferred.push(persisted);
+				producedThisRound++;
+				this._onDidInferLink.fire(persisted);
+			}
+
+			if (producedThisRound === 0 || this._inferred.size >= MAX_INFERRED_LINKS) {
+				break;
+			}
+		}
+
+		this.logService.info(`PLNReasoningService: inferred ${newlyInferred.length} new link(s) over ${iterations} iteration(s)`);
+		return { inferred: newlyInferred, iterations, linksExamined };
+	}
+
+	getInferredLinks(): InferredLink[] {
+		return Array.from(this._inferred.values());
+	}
+
+	reset(): void {
+		for (const id of this._inferred.keys()) {
+			this.hypergraphStore.removeLink(id);
+		}
+		this._inferred.clear();
+		this._inferredIndex.clear();
+		this._truthValues.clear();
+		this.logService.info('PLNReasoningService: reset all inferred links and truth values');
+	}
+
+	// -- Rule application --------------------------------------------------------------------
+
+	private _collectDirectedEdges(): DirectedEdge[] {
+		const edges: DirectedEdge[] = [];
+		const seenLinkIds = new Set<string>();
+		for (const node of this.hypergraphStore.getAllNodes()) {
+			for (const link of this.hypergraphStore.getLinksForNode(node.id)) {
+				if (seenLinkIds.has(link.id) || link.outgoing.length !== 2) {
+					continue;
+				}
+				seenLinkIds.add(link.id);
+				edges.push({
+					linkId: link.id,
+					from: link.outgoing[0],
+					to: link.outgoing[1],
+					truthValue: this._truthValueOf(link.id)
+				});
+			}
+		}
+		return edges;
+	}
+
+	private _priorOf(nodeId: string): number {
+		const node = this.hypergraphStore.getNode(nodeId);
+		const salience = node?.salience_score ?? 0.5;
+		// Clamp away from the extremes: the deduction formula divides by (1 - P(B)),
+		// and a 0/1 prior would either blow up or degenerate the estimate.
+		return Math.max(0.01, Math.min(0.99, salience));
+	}
+
+	/** Deduction: A->B, B->C |- A->C */
+	private _applyDeduction(edges: DirectedEdge[]): InferredLink[] {
+		const byFrom = new Map<string, DirectedEdge[]>();
+		for (const edge of edges) {
+			const bucket = byFrom.get(edge.from);
+			if (bucket) { bucket.push(edge); } else { byFrom.set(edge.from, [edge]); }
+		}
+
+		const results: InferredLink[] = [];
+		for (const ab of edges) {
+			const bcCandidates = byFrom.get(ab.to);
+			if (!bcCandidates) { continue; }
+			for (const bc of bcCandidates) {
+				if (bc.to === ab.from) { continue; } // skip trivial A->B->A cycles
+				const sB = this._priorOf(ab.to);
+				const sC = this._priorOf(bc.to);
+				const denom = 1 - sB;
+				const strength = denom > 0.0001
+					? clamp01(ab.truthValue.strength * bc.truthValue.strength + (1 - ab.truthValue.strength) * (sC - sB * bc.truthValue.strength) / denom)
+					: clamp01(ab.truthValue.strength * bc.truthValue.strength);
+				const confidence = clamp01(ab.truthValue.confidence * bc.truthValue.confidence * DEDUCTION_CONFIDENCE_DISCOUNT);
+				results.push({
+					id: '',
+					from: ab.from,
+					to: bc.to,
+					truthValue: { strength, confidence },
+					rule: 'deduction',
+					premises: [ab.linkId, bc.linkId]
+				});
+			}
+		}
+		return results;
+	}
+
+	/** Inversion: A->B |- B->A (Bayes' rule) */
+	private _applyInversion(edges: DirectedEdge[]): InferredLink[] {
+		const results: InferredLink[] = [];
+		for (const edge of edges) {
+			const sA = this._priorOf(edge.from);
+			const sB = this._priorOf(edge.to);
+			const strength = sB > 0.0001 ? clamp01((edge.truthValue.strength * sA) / sB) : 0;
+			const confidence = clamp01(edge.truthValue.confidence * INVERSION_CONFIDENCE_DISCOUNT);
+			results.push({
+				id: '',
+				from: edge.to,
+				to: edge.from,
+				truthValue: { strength, confidence },
+				rule: 'inversion',
+				premises: [edge.linkId]
+			});
+		}
+		return results;
+	}
+
+	/** Similarity: A->B and B->A |- Similarity(A,B) (symmetric, stored as A->B) */
+	private _applySimilarity(edges: DirectedEdge[]): InferredLink[] {
+		const byPair = new Map<string, DirectedEdge>();
+		for (const edge of edges) {
+			byPair.set(`${edge.from}|${edge.to}`, edge);
+		}
+
+		const results: InferredLink[] = [];
+		const seenPairs = new Set<string>();
+		for (const edge of edges) {
+			const reverse = byPair.get(`${edge.to}|${edge.from}`);
+			if (!reverse) { continue; }
+			const pairKey = [edge.from, edge.to].sort().join('|');
+			if (seenPairs.has(pairKey)) { continue; }
+			seenPairs.add(pairKey);
+
+			const strength = clamp01(Math.sqrt(edge.truthValue.strength * reverse.truthValue.strength));
+			const confidence = clamp01(Math.min(edge.truthValue.confidence, reverse.truthValue.confidence) * SIMILARITY_CONFIDENCE_DISCOUNT);
+			results.push({
+				id: '',
+				from: edge.from,
+				to: edge.to,
+				truthValue: { strength, confidence },
+				rule: 'similarity',
+				premises: [edge.linkId, reverse.linkId]
+			});
+		}
+		return results;
+	}
+
+	private _persistInference(candidate: InferredLink): InferredLink {
+		const id = `pln-${candidate.rule}-${Date.now()}-${++this._inferenceCounter}`;
+		const link: HypergraphLink = {
+			id,
+			link_type: INFERRED_LINK_TYPE,
+			outgoing: [candidate.from, candidate.to],
+			metadata: {
+				inferred: true,
+				rule: candidate.rule,
+				truthValue: candidate.truthValue,
+				premises: candidate.premises
+			}
+		};
+		this.hypergraphStore.addLink(link);
+		this._truthValues.set(id, candidate.truthValue);
+		return { ...candidate, id };
+	}
+}

--- a/src/sql/workbench/services/zonecog/browser/plnReasoningService.ts
+++ b/src/sql/workbench/services/zonecog/browser/plnReasoningService.ts
@@ -41,6 +41,10 @@ interface DirectedEdge {
 	from: string;
 	to: string;
 	truthValue: TruthValue;
+	/** For edges backed by an inferred link: the rule that produced it. */
+	rule?: string;
+	/** For edges backed by an inferred link: the premise link ids it was derived from. */
+	premises?: string[];
 }
 
 /**
@@ -169,11 +173,14 @@ export class PLNReasoningService extends Disposable implements IPLNReasoningServ
 					continue;
 				}
 				seenLinkIds.add(link.id);
+				const premises = link.metadata['premises'];
 				edges.push({
 					linkId: link.id,
 					from: link.outgoing[0],
 					to: link.outgoing[1],
-					truthValue: this._truthValueOf(link.id)
+					truthValue: this._truthValueOf(link.id),
+					rule: link.metadata['inferred'] === true && typeof link.metadata['rule'] === 'string' ? link.metadata['rule'] : undefined,
+					premises: Array.isArray(premises) ? premises.filter((p): p is string => typeof p === 'string') : undefined
 				});
 			}
 		}
@@ -226,6 +233,10 @@ export class PLNReasoningService extends Disposable implements IPLNReasoningServ
 	private _applyInversion(edges: DirectedEdge[]): InferredLink[] {
 		const results: InferredLink[] = [];
 		for (const edge of edges) {
+			// Inverting an inversion only re-derives the original relation with
+			// degraded confidence - pure noise, so inversion-derived edges are
+			// not premises for further inversion.
+			if (edge.rule === 'inversion') { continue; }
 			const sA = this._priorOf(edge.from);
 			const sB = this._priorOf(edge.to);
 			const strength = sB > 0.0001 ? clamp01((edge.truthValue.strength * sA) / sB) : 0;
@@ -254,6 +265,10 @@ export class PLNReasoningService extends Disposable implements IPLNReasoningServ
 		for (const edge of edges) {
 			const reverse = byPair.get(`${edge.to}|${edge.from}`);
 			if (!reverse) { continue; }
+			// If one direction was derived from the other, the pair carries no
+			// independent evidence - similarity from a link and its own
+			// inversion would just double-count the same premise.
+			if (edge.premises?.includes(reverse.linkId) || reverse.premises?.includes(edge.linkId)) { continue; }
 			const pairKey = [edge.from, edge.to].sort().join('|');
 			if (seenPairs.has(pairKey)) { continue; }
 			seenPairs.add(pairKey);

--- a/src/sql/workbench/services/zonecog/browser/zonecog.contribution.ts
+++ b/src/sql/workbench/services/zonecog/browser/zonecog.contribution.ts
@@ -43,6 +43,8 @@ import { ICognitiveProvenanceService } from 'sql/workbench/services/zonecog/comm
 import { CognitiveProvenanceService } from 'sql/workbench/services/zonecog/browser/cognitiveProvenanceService';
 import { ISchemaEvolutionService } from 'sql/workbench/services/zonecog/common/schemaEvolution';
 import { SchemaEvolutionService } from 'sql/workbench/services/zonecog/browser/schemaEvolutionService';
+import { IPLNReasoningService } from 'sql/workbench/services/zonecog/common/plnReasoning';
+import { PLNReasoningService } from 'sql/workbench/services/zonecog/browser/plnReasoningService';
 
 // Register the Hypergraph store (dependency of ZoneCogService)
 registerSingleton(IHypergraphStore, HypergraphStore, InstantiationType.Eager);
@@ -124,3 +126,8 @@ registerSingleton(ICognitiveProvenanceService, CognitiveProvenanceService, Insta
 // Register the Schema Evolution service (snapshot diffing of perceived
 // schemas into a persisted SchemaChange history)
 registerSingleton(ISchemaEvolutionService, SchemaEvolutionService, InstantiationType.Eager);
+
+// Register the PLN Reasoning service (PLN-style truth values and URE-lite
+// forward-chaining deduction/inversion/similarity inference over the
+// hypergraph store's binary directed links)
+registerSingleton(IPLNReasoningService, PLNReasoningService, InstantiationType.Eager);

--- a/src/sql/workbench/services/zonecog/common/plnReasoning.ts
+++ b/src/sql/workbench/services/zonecog/common/plnReasoning.ts
@@ -87,7 +87,10 @@ export interface IPLNReasoningService {
 	 * directed links, repeating until no new conclusions are derived or
 	 * `maxIterations` is reached. New conclusions are persisted as
 	 * hypergraph links (`link_type: 'Inferred'`) so they feed subsequent
-	 * inference passes.
+	 * inference passes. Degenerate derivations that merely recycle their own
+	 * evidence - inverting an inversion, or similarity between a link and
+	 * its own inversion - are skipped, so repeated calls converge to a
+	 * fixed point instead of accumulating noise.
 	 */
 	infer(options?: InferenceOptions): InferenceRunResult;
 

--- a/src/sql/workbench/services/zonecog/common/plnReasoning.ts
+++ b/src/sql/workbench/services/zonecog/common/plnReasoning.ts
@@ -1,0 +1,99 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
+import { Event } from 'vs/base/common/event';
+
+export const IPLNReasoningService = createDecorator<IPLNReasoningService>('plnReasoningService');
+
+// ---------------------------------------------------------------------------
+// PLN reasoning types
+// ---------------------------------------------------------------------------
+
+/**
+ * PLN-style truth value: `strength` is the probability estimate for the
+ * relation holding, `confidence` is the amount of evidence backing that
+ * estimate. Both are in [0, 1].
+ */
+export interface TruthValue {
+	strength: number;
+	confidence: number;
+}
+
+/** Names of the inference rules the URE-lite forward-chainer applies. */
+export type InferenceRuleName = 'deduction' | 'inversion' | 'similarity';
+
+/** A directed binary relation produced by forward-chaining inference. */
+export interface InferredLink {
+	/** Hypergraph link id this conclusion was persisted as. */
+	id: string;
+	from: string;
+	to: string;
+	truthValue: TruthValue;
+	rule: InferenceRuleName;
+	/** IDs of the premise links this conclusion was derived from. */
+	premises: string[];
+}
+
+export interface InferenceRunResult {
+	inferred: InferredLink[];
+	iterations: number;
+	/** Number of binary directed edges considered as inference premises. */
+	linksExamined: number;
+}
+
+export interface InferenceOptions {
+	/** Maximum forward-chaining passes. Default 3. */
+	maxIterations?: number;
+	/** Conclusions with confidence below this are discarded. Default 0.05. */
+	minConfidence?: number;
+}
+
+/**
+ * PLN (Probabilistic Logic Networks) reasoning service - a lightweight
+ * Unified Rule Engine (URE) forward-chainer over the hypergraph store.
+ *
+ * Closes the "AtomSpace Reasoning" roadmap item (Phase 3.2): PLN-style truth
+ * values (strength/confidence) can be attached to any hypergraph link, and
+ * `infer()` repeatedly applies deduction, inversion, and similarity rules to
+ * derive new links from existing ones, persisting each conclusion back into
+ * the hypergraph store so later reasoning passes (and other services) can
+ * build on it. This operates entirely on `HypergraphStore` - it does not
+ * require a real AtomSpace transport (see roadmap note: a real backend
+ * remains separate future work).
+ */
+export interface IPLNReasoningService {
+	readonly _serviceBrand: undefined;
+
+	/** Fired each time a new inferred link is derived and persisted. */
+	readonly onDidInferLink: Event<InferredLink>;
+
+	/**
+	 * Assign or update the truth value for an existing hypergraph link.
+	 * Links with no explicit truth value default to
+	 * `{ strength: 0.9, confidence: 0.5 }` when used as inference premises.
+	 */
+	setTruthValue(linkId: string, truthValue: TruthValue): void;
+
+	/** The truth value explicitly assigned to a link, if any. */
+	getTruthValue(linkId: string): TruthValue | undefined;
+
+	/**
+	 * Run forward-chaining inference over the hypergraph store: applies
+	 * deduction (A->B, B->C => A->C), inversion (A->B => B->A), and
+	 * similarity (A->B and B->A => Similarity(A,B)) rules over binary
+	 * directed links, repeating until no new conclusions are derived or
+	 * `maxIterations` is reached. New conclusions are persisted as
+	 * hypergraph links (`link_type: 'Inferred'`) so they feed subsequent
+	 * inference passes.
+	 */
+	infer(options?: InferenceOptions): InferenceRunResult;
+
+	/** All links inferred so far in this session (persisted, inferred: true). */
+	getInferredLinks(): InferredLink[];
+
+	/** Clear all inferred links and explicit truth-value assignments. */
+	reset(): void;
+}

--- a/src/sql/workbench/services/zonecog/test/browser/plnReasoningService.test.ts
+++ b/src/sql/workbench/services/zonecog/test/browser/plnReasoningService.test.ts
@@ -1,0 +1,210 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { IPLNReasoningService, InferredLink } from 'sql/workbench/services/zonecog/common/plnReasoning';
+import { PLNReasoningService } from 'sql/workbench/services/zonecog/browser/plnReasoningService';
+import { IHypergraphStore, ICognitiveMembraneService, HypergraphNode, HypergraphLink } from 'sql/workbench/services/zonecog/common/zonecogService';
+import { HypergraphStore } from 'sql/workbench/services/zonecog/browser/hypergraphStore';
+import { CognitiveMembraneService } from 'sql/workbench/services/zonecog/browser/cognitiveMembraneService';
+import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
+import { ILogService, NullLogService } from 'vs/platform/log/common/log';
+
+suite('PLN Reasoning Service Tests', () => {
+
+	let instantiationService: TestInstantiationService;
+	let plnService: IPLNReasoningService;
+	let hypergraphStore: IHypergraphStore;
+
+	setup(() => {
+		instantiationService = new TestInstantiationService();
+		instantiationService.stub(ILogService, new NullLogService());
+
+		hypergraphStore = instantiationService.createInstance(HypergraphStore);
+		instantiationService.stub(IHypergraphStore, hypergraphStore);
+
+		const membraneService = instantiationService.createInstance(CognitiveMembraneService);
+		instantiationService.stub(ICognitiveMembraneService, membraneService);
+
+		plnService = instantiationService.createInstance(PLNReasoningService);
+	});
+
+	function node(id: string, salience: number = 0.5): HypergraphNode {
+		return { id, node_type: 'TestNode', content: id, links: [], metadata: {}, salience_score: salience };
+	}
+
+	function link(id: string, from: string, to: string): HypergraphLink {
+		return { id, link_type: 'RelatesTo', outgoing: [from, to], metadata: {} };
+	}
+
+	// --- Truth values ---
+
+	test('should have no truth value assigned by default', () => {
+		assert.strictEqual(plnService.getTruthValue('l1'), undefined);
+	});
+
+	test('should store and retrieve an assigned truth value, clamped to [0,1]', () => {
+		plnService.setTruthValue('l1', { strength: 1.5, confidence: -0.2 });
+		assert.deepStrictEqual(plnService.getTruthValue('l1'), { strength: 1, confidence: 0 });
+	});
+
+	// --- Deduction ---
+
+	test('should derive A->C from A->B and B->C via deduction', () => {
+		hypergraphStore.addNode(node('A', 0.5));
+		hypergraphStore.addNode(node('B', 0.5));
+		hypergraphStore.addNode(node('C', 0.5));
+		hypergraphStore.addLink(link('ab', 'A', 'B'));
+		hypergraphStore.addLink(link('bc', 'B', 'C'));
+		plnService.setTruthValue('ab', { strength: 0.9, confidence: 0.8 });
+		plnService.setTruthValue('bc', { strength: 0.9, confidence: 0.8 });
+
+		const result = plnService.infer({ maxIterations: 1 });
+
+		const deduced = result.inferred.find(l => l.rule === 'deduction' && l.from === 'A' && l.to === 'C');
+		assert.ok(deduced, 'expected a deduced A->C link');
+		assert.ok(deduced!.truthValue.strength > 0 && deduced!.truthValue.strength <= 1);
+		assert.ok(deduced!.truthValue.confidence < 0.8, 'confidence should be discounted below either premise');
+	});
+
+	test('should not deduce a trivial A->B->A cycle back to itself', () => {
+		hypergraphStore.addNode(node('A'));
+		hypergraphStore.addNode(node('B'));
+		hypergraphStore.addLink(link('ab', 'A', 'B'));
+		hypergraphStore.addLink(link('ba', 'B', 'A'));
+
+		const result = plnService.infer({ maxIterations: 1 });
+		assert.strictEqual(result.inferred.find(l => l.rule === 'deduction' && l.from === 'A' && l.to === 'A'), undefined);
+	});
+
+	// --- Inversion ---
+
+	test('should derive B->A from A->B via inversion', () => {
+		hypergraphStore.addNode(node('A', 0.5));
+		hypergraphStore.addNode(node('B', 0.5));
+		hypergraphStore.addLink(link('ab', 'A', 'B'));
+		plnService.setTruthValue('ab', { strength: 0.8, confidence: 0.7 });
+
+		const result = plnService.infer({ maxIterations: 1 });
+		const inverted = result.inferred.find(l => l.rule === 'inversion' && l.from === 'B' && l.to === 'A');
+		assert.ok(inverted, 'expected an inverted B->A link');
+		assert.ok(inverted!.truthValue.confidence < 0.7);
+	});
+
+	// --- Similarity ---
+
+	test('should derive Similarity when both A->B and B->A exist', () => {
+		hypergraphStore.addNode(node('A'));
+		hypergraphStore.addNode(node('B'));
+		hypergraphStore.addLink(link('ab', 'A', 'B'));
+		hypergraphStore.addLink(link('ba', 'B', 'A'));
+		plnService.setTruthValue('ab', { strength: 0.8, confidence: 0.6 });
+		plnService.setTruthValue('ba', { strength: 0.6, confidence: 0.9 });
+
+		const result = plnService.infer({ maxIterations: 1 });
+		const similarity = result.inferred.filter(l => l.rule === 'similarity');
+		assert.strictEqual(similarity.length, 1, 'expected exactly one similarity conclusion for the A/B pair');
+		assert.ok(similarity[0].truthValue.confidence <= 0.6);
+	});
+
+	// --- Persistence & dedup ---
+
+	test('inferred links should be persisted in the hypergraph store', () => {
+		hypergraphStore.addNode(node('A'));
+		hypergraphStore.addNode(node('B'));
+		hypergraphStore.addLink(link('ab', 'A', 'B'));
+		plnService.setTruthValue('ab', { strength: 0.9, confidence: 0.9 });
+
+		const result = plnService.infer({ maxIterations: 1 });
+		assert.ok(result.inferred.length > 0);
+		for (const inferred of result.inferred) {
+			const persisted = hypergraphStore.getLink(inferred.id);
+			assert.ok(persisted, `expected persisted link for ${inferred.id}`);
+			assert.strictEqual(persisted!.link_type, 'Inferred');
+			assert.strictEqual(persisted!.metadata['inferred'], true);
+		}
+	});
+
+	test('should not re-derive the same conclusion twice across separate infer() calls', () => {
+		hypergraphStore.addNode(node('A'));
+		hypergraphStore.addNode(node('B'));
+		hypergraphStore.addLink(link('ab', 'A', 'B'));
+		plnService.setTruthValue('ab', { strength: 0.9, confidence: 0.9 });
+
+		plnService.infer({ maxIterations: 1 });
+		const countAfterFirst = plnService.getInferredLinks().length;
+		plnService.infer({ maxIterations: 1 });
+		const countAfterSecond = plnService.getInferredLinks().length;
+
+		assert.strictEqual(countAfterFirst, countAfterSecond, 'no duplicate conclusions should be added');
+	});
+
+	test('should discard conclusions below the minConfidence threshold', () => {
+		hypergraphStore.addNode(node('A'));
+		hypergraphStore.addNode(node('B'));
+		hypergraphStore.addLink(link('ab', 'A', 'B'));
+		plnService.setTruthValue('ab', { strength: 0.9, confidence: 0.1 });
+
+		const result = plnService.infer({ maxIterations: 1, minConfidence: 0.99 });
+		assert.strictEqual(result.inferred.length, 0);
+	});
+
+	test('should fire onDidInferLink for each new conclusion', () => {
+		hypergraphStore.addNode(node('A'));
+		hypergraphStore.addNode(node('B'));
+		hypergraphStore.addLink(link('ab', 'A', 'B'));
+		plnService.setTruthValue('ab', { strength: 0.9, confidence: 0.9 });
+
+		const fired: InferredLink[] = [];
+		plnService.onDidInferLink(l => fired.push(l));
+		const result = plnService.infer({ maxIterations: 1 });
+
+		assert.strictEqual(fired.length, result.inferred.length);
+	});
+
+	// --- Multi-hop chaining across iterations ---
+
+	test('should chain deduction across multiple iterations (A->B->C->D)', () => {
+		for (const id of ['A', 'B', 'C', 'D']) {
+			hypergraphStore.addNode(node(id, 0.5));
+		}
+		hypergraphStore.addLink(link('ab', 'A', 'B'));
+		hypergraphStore.addLink(link('bc', 'B', 'C'));
+		hypergraphStore.addLink(link('cd', 'C', 'D'));
+		plnService.setTruthValue('ab', { strength: 0.9, confidence: 0.9 });
+		plnService.setTruthValue('bc', { strength: 0.9, confidence: 0.9 });
+		plnService.setTruthValue('cd', { strength: 0.9, confidence: 0.9 });
+
+		const result = plnService.infer({ maxIterations: 3 });
+		const adToD = plnService.getInferredLinks().find(l => l.from === 'A' && l.to === 'D');
+		assert.ok(adToD, 'expected a multi-hop A->D conclusion after several iterations');
+		assert.ok(result.iterations >= 2);
+	});
+
+	// --- Reset ---
+
+	test('reset should clear inferred links, truth values, and persisted nodes', () => {
+		hypergraphStore.addNode(node('A'));
+		hypergraphStore.addNode(node('B'));
+		hypergraphStore.addLink(link('ab', 'A', 'B'));
+		plnService.setTruthValue('ab', { strength: 0.9, confidence: 0.9 });
+		const result = plnService.infer({ maxIterations: 1 });
+		const firstId = result.inferred[0].id;
+
+		plnService.reset();
+
+		assert.deepStrictEqual(plnService.getInferredLinks(), []);
+		assert.strictEqual(plnService.getTruthValue('ab'), undefined);
+		assert.strictEqual(hypergraphStore.getLink(firstId), undefined);
+	});
+
+	// --- Empty graph ---
+
+	test('should return an empty result on an empty hypergraph', () => {
+		const result = plnService.infer();
+		assert.deepStrictEqual(result.inferred, []);
+		assert.strictEqual(result.linksExamined, 0);
+	});
+});

--- a/src/sql/workbench/services/zonecog/test/browser/plnReasoningService.test.ts
+++ b/src/sql/workbench/services/zonecog/test/browser/plnReasoningService.test.ts
@@ -141,6 +141,24 @@ suite('PLN Reasoning Service Tests', () => {
 		assert.strictEqual(countAfterFirst, countAfterSecond, 'no duplicate conclusions should be added');
 	});
 
+	test('should not chain degenerate derivations from a single base link', () => {
+		hypergraphStore.addNode(node('A'));
+		hypergraphStore.addNode(node('B'));
+		hypergraphStore.addLink(link('ab', 'A', 'B'));
+		plnService.setTruthValue('ab', { strength: 0.9, confidence: 0.9 });
+
+		plnService.infer({ maxIterations: 3 });
+		const inferred = plnService.getInferredLinks();
+
+		// Only the B->A inversion is a real conclusion. Inverting that inversion
+		// back into A->B, or deriving Similarity(A,B) from ab and its own
+		// inversion, would just recycle the same evidence.
+		assert.strictEqual(inferred.length, 1);
+		assert.strictEqual(inferred[0].rule, 'inversion');
+		assert.strictEqual(inferred[0].from, 'B');
+		assert.strictEqual(inferred[0].to, 'A');
+	});
+
 	test('should discard conclusions below the minConfidence threshold', () => {
 		hypergraphStore.addNode(node('A'));
 		hypergraphStore.addNode(node('B'));


### PR DESCRIPTION
## Description

Closes the Phase 3.2 "AtomSpace Reasoning" gap in `docs/ZONECOG_ROADMAP.md`: PLN (Probabilistic Logic Networks) integration and a URE (Unified Rule Engine) for inference chains were the two remaining unchecked items not covered by any other in-flight work.

Adds `IPLNReasoningService` / `PLNReasoningService` — a lightweight forward-chaining reasoner over the existing `HypergraphStore`:

- PLN-style truth values (`strength`/`confidence`) can be attached to any hypergraph link via `setTruthValue`/`getTruthValue`; links without an explicit value default to `{ strength: 0.9, confidence: 0.5 }`.
- `infer()` forward-chains three rules over binary directed links (`outgoing.length === 2`) until no new conclusions are derived or `maxIterations` is reached:
  - **Deduction** (A→B, B→C ⊢ A→C) using the standard PLN independence-based formula, with node `salience_score` as a proxy for prior probability.
  - **Inversion** (A→B ⊢ B→A) via Bayes' rule.
  - **Similarity** (A→B and B→A ⊢ Similarity(A,B)) via geometric mean of strengths.
- Conclusions are persisted as `Inferred` hypergraph links (deduped, capped at 1000, discarded below a `minConfidence` threshold) so later inference passes — and other services — can build on them.
- Wired into DI (`zonecog.contribution.ts`) and exposed as a new **"Zone-Cog: Run PLN Inference"** command palette action showing the top conclusions by confidence.

This operates entirely on the in-memory `HypergraphStore`; it does not require a real AtomSpace transport (still open, per the existing roadmap note that a real backend is separate future work).

Note: there is a separate, broader in-flight PR (#48) reimplementing the Phase 5-7 plan from issue #47 (dashboards, Aphrodite integration, DTESN binding, etc.). This PR is scoped to the one concrete, unclaimed gap in Phase 3.2 that isn't mentioned in that plan, to avoid duplicate work.

## Code Changes Checklist

- [x] New or updated **unit tests** added (`plnReasoningService.test.ts` — truth values, all three rules, persistence/dedup, multi-hop chaining, reset, empty graph)
- [ ] All existing tests pass (`npm run test`) — not run in this environment (no `node_modules`); relying on CI
- [x] Code follows [contributing guidelines](https://github.com/microsoft/azuredatastudio/blob/main/CONTRIBUTING.md) (mirrors the existing `SchemaEvolutionService` pattern)
- [x] No UI regressions introduced (additive service + one new command)
- [ ] Logging/telemetry updated if applicable (uses existing `ILogService`/membrane activity recording, consistent with sibling services)
- [x] Cross-platform support checked (pure TypeScript, no platform-specific code)

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/azuredatastudio/blob/main/.github/REVIEW_GUIDELINES.md)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FCVTZj4NhzUzvtLBLctje7)_