### PR TITLE
feat(zonecog): federated hypergraph queries across workbench windows (Phase 3.4)

### DIFF
--- a/docs/ZONECOG_ROADMAP.md
+++ b/docs/ZONECOG_ROADMAP.md
@@ -172,7 +172,7 @@
 
 ### 3.4 Knowledge Graph Enhancement
 - [x] Persistent hypergraph storage — `HypergraphPersistenceService` (IndexedDB, versioned schema, snapshots); a real AtomSpace-Rocks backend remains future work
-- [ ] Federated hypergraph queries (FlareCog integration)
+- [x] Federated hypergraph queries (FlareCog integration) — `IFederatedQueryService`/`FederatedQueryService` (same-machine multi-window query federation over the `ISharedCognitionService` BroadcastChannel transport: `query()` broadcasts a keyword/type/salience filter to joined peer windows and collects per-peer matches with a timeout, `queryMerged()` dedupes by node id keeping the highest salience; a real FlareCog cross-machine federation transport remains future work)
 - [x] Schema evolution tracking — `ISchemaEvolutionService`/`SchemaEvolutionService` (per-connection snapshot diffing of perceived schemas into added/removed/modified `SchemaChange` hypergraph nodes, self-wired to `ISchemaPerceptionService.onDidPerceiveSchema`)
 - [x] Provenance and audit trails for cognitive decisions — `ICognitiveProvenanceService`/`CognitiveProvenanceService` (bounded audit trail, `CognitiveDecision` hypergraph nodes with `EvidencedBy` links, transitive provenance chain resolution)
 

--- a/src/sql/workbench/contrib/zonecog/browser/zonecogActions.contribution.ts
+++ b/src/sql/workbench/contrib/zonecog/browser/zonecogActions.contribution.ts
@@ -36,6 +36,7 @@ import { ICognitiveInsightsService } from 'sql/workbench/services/zonecog/common
 import { ICognitiveTraceService } from 'sql/workbench/services/zonecog/common/cognitiveTrace';
 import { ISharedCognitionService } from 'sql/workbench/services/zonecog/common/sharedCognition';
 import { ICognitiveAnalyticsService } from 'sql/workbench/services/zonecog/common/cognitiveAnalytics';
+import { IFederatedQueryService } from 'sql/workbench/services/zonecog/common/federatedQuery';
 
 const ZONECOG_CATEGORY = { value: localize('zonecog.category', 'Zone-Cog'), original: 'Zone-Cog' };
 
@@ -2390,6 +2391,98 @@ class ZoneCogToggleSharedCognitionAction extends Action2 {
 	}
 }
 
+/**
+ * Action to toggle the federated query session (multi-window hypergraph
+ * query federation)
+ */
+class ZoneCogToggleFederatedQueryAction extends Action2 {
+
+	static ID = 'zonecog.toggleFederatedQuery';
+	constructor() {
+		super({
+			id: ZoneCogToggleFederatedQueryAction.ID,
+			title: { value: localize('zonecog.toggleFederatedQuery', 'Toggle Federated Query Session'), original: 'Toggle Federated Query Session' },
+			category: ZONECOG_CATEGORY,
+			icon: Codicon.broadcast,
+			f1: true,
+			menu: { id: MenuId.CommandPalette },
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const federatedQueryService = accessor.get(IFederatedQueryService);
+		const notificationService = accessor.get(INotificationService);
+
+		const state = federatedQueryService.getState();
+		if (state.active) {
+			federatedQueryService.stopSession();
+			notificationService.info(localize('zonecog.federatedStopped',
+				'Federated query session stopped ({0} queries sent, {1} responses received from {2} peer(s)).',
+				state.queriesSent, state.responsesReceived, state.knownPeers.length));
+			return;
+		}
+
+		if (federatedQueryService.startSession()) {
+			notificationService.info(localize('zonecog.federatedStarted',
+				'Federated query session started - hypergraph queries now also search other workbench windows that join.'));
+		} else {
+			notificationService.error(localize('zonecog.federatedUnavailable',
+				'Federated query is unavailable: BroadcastChannel is not supported in this environment.'));
+		}
+	}
+}
+
+/**
+ * Action to run a federated hypergraph query across this window and any
+ * joined peer windows.
+ */
+class ZoneCogFederatedQueryAction extends Action2 {
+
+	static ID = 'zonecog.federatedQuery';
+	constructor() {
+		super({
+			id: ZoneCogFederatedQueryAction.ID,
+			title: { value: localize('zonecog.federatedQuery', 'Run Federated Hypergraph Query'), original: 'Run Federated Hypergraph Query' },
+			category: ZONECOG_CATEGORY,
+			icon: Codicon.search,
+			f1: true,
+			menu: { id: MenuId.CommandPalette },
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const federatedQueryService = accessor.get(IFederatedQueryService);
+		const quickInputService = accessor.get(IQuickInputService);
+		const notificationService = accessor.get(INotificationService);
+
+		const keyword = await quickInputService.input({
+			prompt: localize('zonecog.federatedQueryPrompt', 'Keyword to search for across this window and joined peer windows (leave empty to match all)'),
+		});
+		if (keyword === undefined) {
+			return;
+		}
+
+		const state = federatedQueryService.getState();
+		const results = await federatedQueryService.query({ keyword: keyword || undefined, limit: 10 });
+
+		const summary = results.map(result => {
+			const label = result.isSelf ? 'this window' : `peer ${result.peerId.substring(0, 8)}`;
+			const nodes = result.nodes.map(n =>
+				`  [${n.node_type}] ${n.content.substring(0, 80)}${n.content.length > 80 ? '...' : ''} (salience: ${n.salience_score.toFixed(2)})`
+			).join('\n');
+			return `${label} (${result.nodes.length} match${result.nodes.length === 1 ? '' : 'es'}):\n${nodes}`;
+		}).join('\n');
+
+		notificationService.info(localize('zonecog.federatedResults',
+			'Federated query results across {0} participant(s):\n{1}', results.length, summary || localize('zonecog.federatedNoMatches', '(no matches)')));
+
+		if (!state.active && state.knownPeers.length === 0) {
+			notificationService.info(localize('zonecog.federatedLocalOnly',
+				'No federated query session is active, so only this window was searched. Start one with "Toggle Federated Query Session" to include other windows.'));
+		}
+	}
+}
+
 // Phase 4 completion actions
 registerAction2(ZoneCogConversationalExplorationAction);
 registerAction2(ZoneCogSchemaDesignAssistantAction);
@@ -2397,6 +2490,8 @@ registerAction2(ZoneCogShowInsightsAction);
 registerAction2(ZoneCogExportTraceAction);
 registerAction2(ZoneCogImportTraceAction);
 registerAction2(ZoneCogToggleSharedCognitionAction);
+registerAction2(ZoneCogToggleFederatedQueryAction);
+registerAction2(ZoneCogFederatedQueryAction);
 
 // Register the cognitive loop status bar contribution so the loop state is
 // always visible in the workbench status bar.

--- a/src/sql/workbench/services/zonecog/README.md
+++ b/src/sql/workbench/services/zonecog/README.md
@@ -324,6 +324,11 @@ Available through Command Palette (`Ctrl+Shift+P`):
 - `Zone-Cog: Show Workflow Execution History` — View recent executions
 - `Zone-Cog: Toggle Workflow Enabled` — Enable/disable a workflow
 
+### Phase 3.4 / 4.4 - Shared and Federated Cognition
+- `Zone-Cog: Toggle Shared Cognition Session` — Sync hypergraph node/link upserts with other workbench windows on this machine
+- `Zone-Cog: Toggle Federated Query Session` — Join same-machine query federation so hypergraph queries also search other windows
+- `Zone-Cog: Run Federated Hypergraph Query` — Search this window (and any joined peer windows) by keyword/type/salience
+
 ## Panel Views
 
 The Zone-Cog panel (View > Zone-Cog) includes seven dashboard views:

--- a/src/sql/workbench/services/zonecog/browser/federatedQueryService.ts
+++ b/src/sql/workbench/services/zonecog/browser/federatedQueryService.ts
@@ -1,0 +1,254 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import {
+	IFederatedQueryService,
+	FederatedQueryFilter,
+	FederatedQueryResult,
+	FederatedQueryState
+} from 'sql/workbench/services/zonecog/common/federatedQuery';
+import { IHypergraphStore, ICognitiveMembraneService, HypergraphNode } from 'sql/workbench/services/zonecog/common/zonecogService';
+import { ISharedCognitionChannel } from 'sql/workbench/services/zonecog/browser/sharedCognitionService';
+import { Disposable } from 'vs/base/common/lifecycle';
+import { Emitter, Event } from 'vs/base/common/event';
+import { ILogService } from 'vs/platform/log/common/log';
+import { generateUuid } from 'vs/base/common/uuid';
+
+/** Channel name shared by all participating workbench windows. */
+const CHANNEL_NAME = 'zonecog-federated-query';
+
+/** Default cap on nodes returned by a single participant for one query. */
+const DEFAULT_LIMIT = 25;
+
+/** Default time to wait for peer responses before resolving with whatever arrived. */
+const DEFAULT_TIMEOUT_MS = 300;
+
+interface HelloMessage { type: 'hello'; peerId: string; reply: boolean }
+interface QueryRequestMessage { type: 'query-request'; peerId: string; requestId: string; filter: FederatedQueryFilter }
+interface QueryResponseMessage { type: 'query-response'; peerId: string; requestId: string; nodes: HypergraphNode[] }
+type FederatedQueryMessage = HelloMessage | QueryRequestMessage | QueryResponseMessage;
+
+interface PendingQuery {
+	results: FederatedQueryResult[];
+	awaiting: Set<string>;
+	timer: ReturnType<typeof setTimeout>;
+	resolve: (results: FederatedQueryResult[]) => void;
+}
+
+/**
+ * Implementation of the federated hypergraph query service.
+ *
+ * Broadcasts query requests to same-machine peer windows over a
+ * BroadcastChannel (mirroring {@link ISharedCognitionService}'s transport)
+ * and aggregates their matching nodes alongside the local result set.
+ */
+export class FederatedQueryService extends Disposable implements IFederatedQueryService {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _peerId = generateUuid();
+	private readonly _knownPeers = new Set<string>();
+	private readonly _pending = new Map<string, PendingQuery>();
+	private _channel: ISharedCognitionChannel | undefined;
+	private _queriesSent = 0;
+	private _responsesReceived = 0;
+	private _requestsAnswered = 0;
+
+	private readonly _onDidChangeSessionState = this._register(new Emitter<FederatedQueryState>());
+	readonly onDidChangeSessionState: Event<FederatedQueryState> = this._onDidChangeSessionState.event;
+
+	constructor(
+		@ILogService private readonly logService: ILogService,
+		@IHypergraphStore private readonly hypergraphStore: IHypergraphStore,
+		@ICognitiveMembraneService private readonly membraneService: ICognitiveMembraneService
+	) {
+		super();
+	}
+
+	// -- Session lifecycle -----------------------------------------------------------
+
+	startSession(): boolean {
+		if (this._channel) {
+			return true;
+		}
+		const channel = this._createChannel(CHANNEL_NAME);
+		if (!channel) {
+			this.logService.warn('FederatedQueryService: BroadcastChannel unavailable, cannot start federated session');
+			return false;
+		}
+		this.membraneService.recordActivity('somatic');
+		this._channel = channel;
+		channel.onmessage = event => this._onMessage(event.data);
+		this._post({ type: 'hello', peerId: this._peerId, reply: false });
+		this.logService.info(`FederatedQueryService: federated query session started (peer ${this._peerId})`);
+		this._onDidChangeSessionState.fire(this.getState());
+		return true;
+	}
+
+	stopSession(): void {
+		if (!this._channel) {
+			return;
+		}
+		this._channel.onmessage = null;
+		this._channel.close();
+		this._channel = undefined;
+		for (const pending of this._pending.values()) {
+			clearTimeout(pending.timer);
+			pending.resolve(pending.results);
+		}
+		this._pending.clear();
+		this.logService.info('FederatedQueryService: federated query session stopped');
+		this._onDidChangeSessionState.fire(this.getState());
+	}
+
+	getState(): FederatedQueryState {
+		return {
+			active: this._channel !== undefined,
+			peerId: this._peerId,
+			knownPeers: Array.from(this._knownPeers),
+			queriesSent: this._queriesSent,
+			responsesReceived: this._responsesReceived,
+			requestsAnswered: this._requestsAnswered
+		};
+	}
+
+	override dispose(): void {
+		this.stopSession();
+		super.dispose();
+	}
+
+	// -- Querying ---------------------------------------------------------------------
+
+	async query(filter: FederatedQueryFilter, timeoutMs: number = DEFAULT_TIMEOUT_MS): Promise<FederatedQueryResult[]> {
+		this.membraneService.recordActivity('cerebral');
+		const localResult: FederatedQueryResult = { peerId: this._peerId, isSelf: true, nodes: this._matchLocal(filter) };
+
+		if (!this._channel || this._knownPeers.size === 0) {
+			return [localResult];
+		}
+
+		this.membraneService.recordActivity('somatic');
+		const requestId = generateUuid();
+		const awaiting = new Set(this._knownPeers);
+
+		const responses = await new Promise<FederatedQueryResult[]>(resolve => {
+			const timer = setTimeout(() => {
+				const pending = this._pending.get(requestId);
+				if (pending) {
+					this._pending.delete(requestId);
+					pending.resolve(pending.results);
+				}
+			}, timeoutMs);
+			this._pending.set(requestId, { results: [], awaiting, timer, resolve });
+			this._post({ type: 'query-request', peerId: this._peerId, requestId, filter });
+			this._queriesSent++;
+		});
+
+		return [localResult, ...responses];
+	}
+
+	async queryMerged(filter: FederatedQueryFilter, timeoutMs?: number): Promise<HypergraphNode[]> {
+		const results = await this.query(filter, timeoutMs);
+		const byId = new Map<string, HypergraphNode>();
+		for (const result of results) {
+			for (const node of result.nodes) {
+				const existing = byId.get(node.id);
+				if (!existing || node.salience_score > existing.salience_score) {
+					byId.set(node.id, node);
+				}
+			}
+		}
+		const merged = Array.from(byId.values()).sort((a, b) => b.salience_score - a.salience_score);
+		const limit = filter.limit ?? DEFAULT_LIMIT;
+		return merged.slice(0, limit);
+	}
+
+	// -- Matching -----------------------------------------------------------------------
+
+	private _matchLocal(filter: FederatedQueryFilter): HypergraphNode[] {
+		const candidates = filter.nodeType ? this.hypergraphStore.getNodesByType(filter.nodeType) : this.hypergraphStore.getAllNodes();
+		const keyword = filter.keyword?.toLowerCase();
+		const minSalience = filter.minSalience ?? 0;
+		const matched = candidates.filter(node =>
+			node.salience_score >= minSalience &&
+			(!keyword || node.content.toLowerCase().includes(keyword))
+		);
+		matched.sort((a, b) => b.salience_score - a.salience_score);
+		return matched.slice(0, filter.limit ?? DEFAULT_LIMIT);
+	}
+
+	// -- Transport ------------------------------------------------------------------------
+
+	/**
+	 * Create the underlying channel. Overridable so tests can substitute a
+	 * fake transport; returns undefined when BroadcastChannel is unavailable.
+	 */
+	protected _createChannel(name: string): ISharedCognitionChannel | undefined {
+		if (typeof BroadcastChannel === 'undefined') {
+			return undefined;
+		}
+		const raw = new BroadcastChannel(name);
+		const adapter: ISharedCognitionChannel = {
+			postMessage: message => raw.postMessage(message),
+			close: () => raw.close(),
+			onmessage: null
+		};
+		raw.onmessage = event => adapter.onmessage?.({ data: event.data });
+		return adapter;
+	}
+
+	private _post(message: FederatedQueryMessage): void {
+		if (!this._channel) {
+			return;
+		}
+		try {
+			this._channel.postMessage(message);
+		} catch (e) {
+			this.logService.warn(`FederatedQueryService: failed to post message: ${e instanceof Error ? e.message : String(e)}`);
+		}
+	}
+
+	private _onMessage(data: unknown): void {
+		const message = data as FederatedQueryMessage;
+		if (typeof message !== 'object' || message === null || typeof message.peerId !== 'string' || message.peerId === this._peerId) {
+			return;
+		}
+
+		if (message.type === 'hello') {
+			const isNewPeer = !this._knownPeers.has(message.peerId);
+			this._knownPeers.add(message.peerId);
+			if (isNewPeer && !message.reply) {
+				this._post({ type: 'hello', peerId: this._peerId, reply: true });
+			}
+			this._onDidChangeSessionState.fire(this.getState());
+			return;
+		}
+
+		if (message.type === 'query-request' && typeof message.requestId === 'string' && message.filter) {
+			this._knownPeers.add(message.peerId);
+			this.membraneService.recordActivity('cerebral');
+			const nodes = this._matchLocal(message.filter);
+			this._requestsAnswered++;
+			this._post({ type: 'query-response', peerId: this._peerId, requestId: message.requestId, nodes });
+			return;
+		}
+
+		if (message.type === 'query-response' && typeof message.requestId === 'string' && Array.isArray(message.nodes)) {
+			const pending = this._pending.get(message.requestId);
+			if (!pending) {
+				return;
+			}
+			pending.results.push({ peerId: message.peerId, isSelf: false, nodes: message.nodes });
+			pending.awaiting.delete(message.peerId);
+			this._responsesReceived++;
+			this._onDidChangeSessionState.fire(this.getState());
+			if (pending.awaiting.size === 0) {
+				clearTimeout(pending.timer);
+				this._pending.delete(message.requestId);
+				pending.resolve(pending.results);
+			}
+		}
+	}
+}

--- a/src/sql/workbench/services/zonecog/browser/zonecog.contribution.ts
+++ b/src/sql/workbench/services/zonecog/browser/zonecog.contribution.ts
@@ -53,6 +53,8 @@ import { CognitiveTraceService } from 'sql/workbench/services/zonecog/browser/co
 import { ISharedCognitionService } from 'sql/workbench/services/zonecog/common/sharedCognition';
 import { SharedCognitionService } from 'sql/workbench/services/zonecog/browser/sharedCognitionService';
 import { CognitiveAnalyticsService } from 'sql/workbench/services/zonecog/browser/cognitiveAnalyticsService';
+import { IFederatedQueryService } from 'sql/workbench/services/zonecog/common/federatedQuery';
+import { FederatedQueryService } from 'sql/workbench/services/zonecog/browser/federatedQueryService';
 
 // Register the Hypergraph store (dependency of ZoneCogService)
 registerSingleton(IHypergraphStore, HypergraphStore, InstantiationType.Eager);
@@ -157,3 +159,7 @@ registerSingleton(ICognitiveTraceService, CognitiveTraceService, InstantiationTy
 // Register the Shared Cognition service (multi-window shared hypergraph
 // state over a BroadcastChannel)
 registerSingleton(ISharedCognitionService, SharedCognitionService, InstantiationType.Eager);
+
+// Register the Federated Query service (same-machine multi-window
+// hypergraph query federation over a BroadcastChannel; Phase 3.4)
+registerSingleton(IFederatedQueryService, FederatedQueryService, InstantiationType.Eager);

--- a/src/sql/workbench/services/zonecog/common/federatedQuery.ts
+++ b/src/sql/workbench/services/zonecog/common/federatedQuery.ts
@@ -1,0 +1,98 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
+import { Event } from 'vs/base/common/event';
+import { HypergraphNode } from 'sql/workbench/services/zonecog/common/zonecogService';
+
+export const IFederatedQueryService = createDecorator<IFederatedQueryService>('federatedQueryService');
+
+// ---------------------------------------------------------------------------
+// Federated query types
+// ---------------------------------------------------------------------------
+
+/** Criteria used to match hypergraph nodes, locally and on remote peers. */
+export interface FederatedQueryFilter {
+	/** Exact node_type match. */
+	nodeType?: string;
+	/** Case-insensitive substring match against node content. */
+	keyword?: string;
+	/** Minimum salience_score, inclusive. */
+	minSalience?: number;
+	/** Maximum nodes returned per participant (local or remote). Default 25. */
+	limit?: number;
+}
+
+/** Nodes contributed by a single participant (self or a remote peer) for one query. */
+export interface FederatedQueryResult {
+	peerId: string;
+	/** True for the participant that issued the query. */
+	isSelf: boolean;
+	nodes: HypergraphNode[];
+}
+
+/** State of the federated query session. */
+export interface FederatedQueryState {
+	active: boolean;
+	/** Stable identifier of this participant. */
+	peerId: string;
+	/** Peer ids seen since the session started (excluding self). */
+	knownPeers: string[];
+	/** Query requests broadcast to peers since the session started. */
+	queriesSent: number;
+	/** Query responses received from peers since the session started. */
+	responsesReceived: number;
+	/** Query requests answered on behalf of a peer since the session started. */
+	requestsAnswered: number;
+}
+
+// ---------------------------------------------------------------------------
+// Service interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Federated hypergraph query service.
+ *
+ * Same-machine slice of the Phase 3.4 "Federated hypergraph queries" roadmap
+ * item, built on the same BroadcastChannel transport as
+ * {@link ISharedCognitionService}: a query is answered locally and, while a
+ * session is active, also broadcast to every other workbench window on this
+ * machine, whose matching nodes are collected back and returned per
+ * participant. A true FlareCog cross-machine federation transport remains
+ * future work.
+ */
+export interface IFederatedQueryService {
+	readonly _serviceBrand: undefined;
+
+	/** Fired when the session starts or stops, or peers/counters change. */
+	readonly onDidChangeSessionState: Event<FederatedQueryState>;
+
+	/**
+	 * Start federating: opens the channel and announces this peer. Returns
+	 * false when BroadcastChannel is unavailable in the current environment.
+	 * Local-only querying via {@link query} still works without a session.
+	 */
+	startSession(): boolean;
+
+	/** Stop federating and close the channel. */
+	stopSession(): void;
+
+	/** Current session state. */
+	getState(): FederatedQueryState;
+
+	/**
+	 * Run a query against the local hypergraph and, when a session is
+	 * active, against every known peer. Resolves once every known peer has
+	 * answered or `timeoutMs` elapses, whichever is first.
+	 */
+	query(filter: FederatedQueryFilter, timeoutMs?: number): Promise<FederatedQueryResult[]>;
+
+	/**
+	 * Convenience wrapper over {@link query} that flattens every
+	 * participant's nodes into a single list, deduplicated by node id
+	 * (highest salience_score wins), sorted by salience_score descending.
+	 */
+	queryMerged(filter: FederatedQueryFilter, timeoutMs?: number): Promise<HypergraphNode[]>;
+}

--- a/src/sql/workbench/services/zonecog/test/browser/federatedQueryService.test.ts
+++ b/src/sql/workbench/services/zonecog/test/browser/federatedQueryService.test.ts
@@ -1,0 +1,202 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { FederatedQueryService } from 'sql/workbench/services/zonecog/browser/federatedQueryService';
+import { ISharedCognitionChannel } from 'sql/workbench/services/zonecog/browser/sharedCognitionService';
+import { IHypergraphStore, ICognitiveMembraneService } from 'sql/workbench/services/zonecog/common/zonecogService';
+import { HypergraphStore } from 'sql/workbench/services/zonecog/browser/hypergraphStore';
+import { CognitiveMembraneService } from 'sql/workbench/services/zonecog/browser/cognitiveMembraneService';
+import { ILogService, NullLogService } from 'vs/platform/log/common/log';
+
+/**
+ * In-memory hub standing in for BroadcastChannel: messages posted by one
+ * channel are delivered synchronously to every other channel on the hub.
+ */
+class FakeChannelHub {
+	private readonly _channels: FakeChannel[] = [];
+
+	connect(): FakeChannel {
+		const channel = new FakeChannel(this);
+		this._channels.push(channel);
+		return channel;
+	}
+
+	broadcast(sender: FakeChannel, message: unknown): void {
+		for (const channel of this._channels) {
+			if (channel !== sender && !channel.closed && channel.onmessage) {
+				channel.onmessage({ data: message });
+			}
+		}
+	}
+}
+
+class FakeChannel implements ISharedCognitionChannel {
+	closed = false;
+	onmessage: ((event: { data: unknown }) => void) | null = null;
+	constructor(private readonly hub: FakeChannelHub) { }
+	postMessage(message: unknown): void {
+		this.hub.broadcast(this, message);
+	}
+	close(): void {
+		this.closed = true;
+	}
+}
+
+/** Service variant whose transport is the in-memory hub. */
+class TestFederatedQueryService extends FederatedQueryService {
+	constructor(
+		private readonly hub: FakeChannelHub | undefined,
+		logService: ILogService,
+		hypergraphStore: IHypergraphStore,
+		membraneService: ICognitiveMembraneService
+	) {
+		super(logService, hypergraphStore, membraneService);
+	}
+	protected override _createChannel(): ISharedCognitionChannel | undefined {
+		return this.hub?.connect();
+	}
+}
+
+suite('Federated Query Service Tests', () => {
+
+	function makeParticipant(hub: FakeChannelHub | undefined): { service: TestFederatedQueryService; store: IHypergraphStore } {
+		const logService = new NullLogService();
+		const store = new HypergraphStore(logService);
+		const membrane = new CognitiveMembraneService(logService);
+		const service = new TestFederatedQueryService(hub, logService, store, membrane);
+		return { service, store };
+	}
+
+	function node(id: string, content: string, salience = 0.5) {
+		return { id, node_type: 'TestNode', content, links: [], metadata: {}, salience_score: salience };
+	}
+
+	test('should be inactive until started', () => {
+		const { service } = makeParticipant(new FakeChannelHub());
+		assert.strictEqual(service.getState().active, false);
+		assert.ok(service.startSession());
+		assert.strictEqual(service.getState().active, true);
+		service.stopSession();
+		assert.strictEqual(service.getState().active, false);
+	});
+
+	test('startSession should report failure when the transport is unavailable', () => {
+		const { service } = makeParticipant(undefined);
+		assert.strictEqual(service.startSession(), false);
+	});
+
+	test('query without a session should return local results only', async () => {
+		const { service, store } = makeParticipant(undefined);
+		store.addNode(node('n1', 'local knowledge'));
+
+		const results = await service.query({});
+
+		assert.strictEqual(results.length, 1);
+		assert.strictEqual(results[0].isSelf, true);
+		assert.strictEqual(results[0].nodes.length, 1);
+	});
+
+	test('query with no known peers should return local results only even when active', async () => {
+		const { service, store } = makeParticipant(new FakeChannelHub());
+		service.startSession();
+		store.addNode(node('n1', 'local knowledge'));
+
+		const results = await service.query({});
+
+		assert.strictEqual(results.length, 1);
+		assert.strictEqual(results[0].isSelf, true);
+	});
+
+	test('query should collect matches from peers', async () => {
+		const hub = new FakeChannelHub();
+		const a = makeParticipant(hub);
+		const b = makeParticipant(hub);
+		a.service.startSession();
+		b.service.startSession();
+
+		a.store.addNode(node('a1', 'alpha secret'));
+		b.store.addNode(node('b1', 'beta secret'));
+		b.store.addNode(node('b2', 'unrelated'));
+
+		const results = await a.service.query({ keyword: 'secret' }, 500);
+
+		assert.strictEqual(results.length, 2);
+		const self = results.find(r => r.isSelf);
+		const peer = results.find(r => !r.isSelf);
+		assert.ok(self);
+		assert.ok(peer);
+		assert.strictEqual(self!.nodes.length, 1);
+		assert.strictEqual(self!.nodes[0].id, 'a1');
+		assert.strictEqual(peer!.nodes.length, 1);
+		assert.strictEqual(peer!.nodes[0].id, 'b1');
+	});
+
+	test('queryMerged should dedupe and sort by salience', async () => {
+		const hub = new FakeChannelHub();
+		const a = makeParticipant(hub);
+		const b = makeParticipant(hub);
+		a.service.startSession();
+		b.service.startSession();
+
+		a.store.addNode(node('shared', 'shared content', 0.3));
+		b.store.addNode(node('shared', 'shared content', 0.9));
+		b.store.addNode(node('other', 'shared content too', 0.5));
+
+		const merged = await a.service.queryMerged({ keyword: 'shared' }, 500);
+
+		assert.strictEqual(merged.length, 2);
+		assert.strictEqual(merged[0].id, 'shared');
+		assert.strictEqual(merged[0].salience_score, 0.9);
+		assert.strictEqual(merged[1].id, 'other');
+	});
+
+	test('nodeType and minSalience filters should narrow matches', async () => {
+		const hub = new FakeChannelHub();
+		const a = makeParticipant(hub);
+		const b = makeParticipant(hub);
+		a.service.startSession();
+		b.service.startSession();
+
+		b.store.addNode({ id: 't1', node_type: 'Wanted', content: 'x', links: [], metadata: {}, salience_score: 0.8 });
+		b.store.addNode({ id: 't2', node_type: 'Wanted', content: 'x', links: [], metadata: {}, salience_score: 0.1 });
+		b.store.addNode({ id: 't3', node_type: 'Other', content: 'x', links: [], metadata: {}, salience_score: 0.9 });
+
+		const results = await a.service.query({ nodeType: 'Wanted', minSalience: 0.5 }, 500);
+		const peer = results.find(r => !r.isSelf);
+
+		assert.strictEqual(peer!.nodes.length, 1);
+		assert.strictEqual(peer!.nodes[0].id, 't1');
+	});
+
+	test('stopSession should resolve pending queries immediately', async () => {
+		const hub = new FakeChannelHub();
+		const a = makeParticipant(hub);
+		const b = makeParticipant(hub);
+		a.service.startSession();
+		b.service.startSession();
+
+		const pending = a.service.query({}, 5000);
+		a.service.stopSession();
+
+		const results = await pending;
+		assert.ok(results.length >= 1);
+	});
+
+	test('state counters should track sent queries and answered requests', async () => {
+		const hub = new FakeChannelHub();
+		const a = makeParticipant(hub);
+		const b = makeParticipant(hub);
+		a.service.startSession();
+		b.service.startSession();
+
+		b.store.addNode(node('b1', 'x'));
+		await a.service.query({}, 500);
+
+		assert.strictEqual(a.service.getState().queriesSent, 1);
+		assert.strictEqual(a.service.getState().responsesReceived, 1);
+		assert.strictEqual(b.service.getState().requestsAnswered, 1);
+	});
+});


### PR DESCRIPTION
## Description

Proceeds with the next open item on the ZoneCog roadmap (`docs/ZONECOG_ROADMAP.md`, Phase 3.4: Knowledge Graph Enhancement): **Federated hypergraph queries (FlareCog integration)**.

This lands the same-machine slice of that item, built on the same `BroadcastChannel` transport already used by `ISharedCognitionService` (Phase 4.4):

- New `IFederatedQueryService` / `FederatedQueryService` (`common/federatedQuery.ts`, `browser/federatedQueryService.ts`):
  - `query(filter, timeoutMs?)` matches nodes locally by `nodeType` / `keyword` / `minSalience`, and — once a session is joined — broadcasts the same filter to peer workbench windows and aggregates their per-peer matches within a timeout.
  - `queryMerged(...)` flattens all participants' results, dedupes by node id (highest `salience_score` wins), and returns them sorted by salience.
  - `startSession()` / `stopSession()` mirror `SharedCognitionService`'s hello-handshake peer discovery.
- Registered as an eager singleton in `zonecog.contribution.ts`.
- Two new Command Palette actions in `zonecogActions.contribution.ts`: `Zone-Cog: Toggle Federated Query Session` and `Zone-Cog: Run Federated Hypergraph Query`.
- `docs/ZONECOG_ROADMAP.md` and `src/sql/workbench/services/zonecog/README.md` updated to reflect the new service and commands.

A true FlareCog cross-machine federation transport remains explicitly out of scope / future work, consistent with how the existing Shared Cognition Phase 4.4 entry documents the same same-machine-only boundary.

## Code Changes Checklist

- [x] New or updated **unit tests** added — `test/browser/federatedQueryService.test.ts` (session lifecycle, local-only queries, peer aggregation, `queryMerged` dedupe/sort, type/salience filtering, session-stop resolving pending queries, state counters), modeled on the existing `sharedCognitionService.test.ts` fake-channel-hub pattern.
- [ ] All existing tests pass (`npm run test`) — this environment's outbound network access blocks the full `yarn install` needed to run the real Mocha suite (GitHub codeload dependency fetch returns 403 through the proxy). Verified instead via `tsc --noEmit` against `src/tsconfig.json` with a manually assembled `@types` set: zero new errors introduced (diff against a pre-change baseline is empty aside from the expected `Cannot find module 'assert'` line for the new test file, identical to every other zonecog test file in this constrained environment).
- [x] Code follows [contributing guidelines](https://github.com/microsoft/azuredatastudio/blob/main/CONTRIBUTING.md) — mirrors the existing `ISharedCognitionService`/`SharedCognitionService` service pattern (`createDecorator` in `common/`, `Disposable` impl in `browser/`, `registerSingleton(..., InstantiationType.Eager)`, `Emitter`/`Event`, membrane activity recording).
- [x] No UI regressions introduced — additive only; no existing files' behavior changed.
- [x] Logging/telemetry updated if applicable — uses `ILogService` and `ICognitiveMembraneService.recordActivity()` consistent with sibling services.
- [x] Cross-platform support checked (Windows, macOS, Linux if relevant) — pure TypeScript/BroadcastChannel, no platform-specific code.

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/azuredatastudio/blob/main/.github/REVIEW_GUIDELINES.md)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GcEbZyW2G2K1BipeBjpZDN)_