### PR TITLE
feat(zonecog): hypergraph semantic search via Aphrodite embeddings (Phase 3.4)

### DIFF
--- a/docs/ZONECOG_ROADMAP.md
+++ b/docs/ZONECOG_ROADMAP.md
@@ -175,6 +175,7 @@
 - [ ] Federated hypergraph queries (FlareCog integration)
 - [x] Schema evolution tracking — `ISchemaEvolutionService`/`SchemaEvolutionService` (per-connection snapshot diffing of perceived schemas into added/removed/modified `SchemaChange` hypergraph nodes, self-wired to `ISchemaPerceptionService.onDidPerceiveSchema`)
 - [x] Provenance and audit trails for cognitive decisions — `ICognitiveProvenanceService`/`CognitiveProvenanceService` (bounded audit trail, `CognitiveDecision` hypergraph nodes with `EvidencedBy` links, transitive provenance chain resolution)
+- [x] Semantic (embedding-based) search over hypergraph nodes — `IHypergraphSemanticSearchService`/`HypergraphSemanticSearchService` (closes the "Embedding Support" item of the Aphrodite deep-integration plan, issue #53 §5.3: nodes and queries embedded via `IAphroditeService.embed()` when connected, deterministic local hashing-trick bag-of-words fallback otherwise; cosine-similarity ranking with lazy re-indexing on node content changes)
 
 ---
 

--- a/src/sql/workbench/contrib/zonecog/browser/zonecogActions.contribution.ts
+++ b/src/sql/workbench/contrib/zonecog/browser/zonecogActions.contribution.ts
@@ -36,6 +36,7 @@ import { ICognitiveInsightsService } from 'sql/workbench/services/zonecog/common
 import { ICognitiveTraceService } from 'sql/workbench/services/zonecog/common/cognitiveTrace';
 import { ISharedCognitionService } from 'sql/workbench/services/zonecog/common/sharedCognition';
 import { ICognitiveAnalyticsService } from 'sql/workbench/services/zonecog/common/cognitiveAnalytics';
+import { IHypergraphSemanticSearchService } from 'sql/workbench/services/zonecog/common/hypergraphSemanticSearch';
 
 const ZONECOG_CATEGORY = { value: localize('zonecog.category', 'Zone-Cog'), original: 'Zone-Cog' };
 
@@ -2390,6 +2391,84 @@ class ZoneCogToggleSharedCognitionAction extends Action2 {
 	}
 }
 
+/**
+ * Action to index the hypergraph for semantic search
+ */
+class ZoneCogIndexSemanticSearchAction extends Action2 {
+
+	static ID = 'zonecog.indexSemanticSearch';
+	constructor() {
+		super({
+			id: ZoneCogIndexSemanticSearchAction.ID,
+			title: { value: localize('zonecog.indexSemanticSearch', 'Index Hypergraph for Semantic Search'), original: 'Index Hypergraph for Semantic Search' },
+			category: ZONECOG_CATEGORY,
+			icon: Codicon.search,
+			f1: true,
+			menu: { id: MenuId.CommandPalette },
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const searchService = accessor.get(IHypergraphSemanticSearchService);
+		const notificationService = accessor.get(INotificationService);
+
+		const indexed = await searchService.indexAll();
+		notificationService.info(localize('zonecog.indexSemanticSearchDone',
+			'Indexed {0} hypergraph node(s) for semantic search ({1} total in index).',
+			indexed, searchService.getIndexedCount()));
+	}
+}
+
+/**
+ * Action to run a semantic search over the hypergraph
+ */
+class ZoneCogSemanticSearchAction extends Action2 {
+
+	static ID = 'zonecog.semanticSearch';
+	constructor() {
+		super({
+			id: ZoneCogSemanticSearchAction.ID,
+			title: { value: localize('zonecog.semanticSearch', 'Semantic Search Hypergraph'), original: 'Semantic Search Hypergraph' },
+			category: ZONECOG_CATEGORY,
+			icon: Codicon.search,
+			f1: true,
+			menu: { id: MenuId.CommandPalette },
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const searchService = accessor.get(IHypergraphSemanticSearchService);
+		const hypergraphStore = accessor.get(IHypergraphStore);
+		const notificationService = accessor.get(INotificationService);
+		const quickInputService = accessor.get(IQuickInputService);
+
+		if (hypergraphStore.nodeCount() === 0) {
+			notificationService.info(localize('zonecog.semanticSearchEmpty', 'Hypergraph is empty. Process a query first to populate it.'));
+			return;
+		}
+
+		const query = await quickInputService.input({
+			placeHolder: localize('zonecog.semanticSearchPlaceholder', 'Describe what you are looking for (e.g. "tables about customer orders")'),
+			prompt: localize('zonecog.semanticSearchPrompt', 'Semantic Search Hypergraph'),
+		});
+		if (!query || query.trim().length === 0) {
+			return;
+		}
+
+		const results = await searchService.search(query, 10);
+		if (results.length === 0) {
+			notificationService.info(localize('zonecog.semanticSearchNoResults', 'No matching hypergraph nodes found for "{0}".', query));
+			return;
+		}
+
+		const summary = results.map(r =>
+			`[${r.node.node_type}] ${r.node.content.substring(0, 80)}${r.node.content.length > 80 ? '...' : ''} (score: ${r.score.toFixed(3)})`
+		).join('\n');
+
+		notificationService.info(localize('zonecog.semanticSearchResults', 'Semantic Search Results for "{0}":\n{1}', query, summary));
+	}
+}
+
 // Phase 4 completion actions
 registerAction2(ZoneCogConversationalExplorationAction);
 registerAction2(ZoneCogSchemaDesignAssistantAction);
@@ -2397,6 +2476,8 @@ registerAction2(ZoneCogShowInsightsAction);
 registerAction2(ZoneCogExportTraceAction);
 registerAction2(ZoneCogImportTraceAction);
 registerAction2(ZoneCogToggleSharedCognitionAction);
+registerAction2(ZoneCogIndexSemanticSearchAction);
+registerAction2(ZoneCogSemanticSearchAction);
 
 // Register the cognitive loop status bar contribution so the loop state is
 // always visible in the workbench status bar.

--- a/src/sql/workbench/services/zonecog/README.md
+++ b/src/sql/workbench/services/zonecog/README.md
@@ -317,6 +317,8 @@ Available through Command Palette (`Ctrl+Shift+P`):
 - `Zone-Cog: Connect to Aphrodite Engine` — Connect to local LLM inference
 - `Zone-Cog: Show Aphrodite Engine Status` — View model and performance stats
 - `Zone-Cog: Run Aphrodite Completion` — Test LLM inference
+- `Zone-Cog: Index Hypergraph for Semantic Search` — Embed hypergraph nodes for similarity search (`IAphroditeService.embed()` when connected, local hashing-trick fallback otherwise)
+- `Zone-Cog: Semantic Search Hypergraph` — Rank hypergraph nodes by cosine similarity to a natural-language query
 
 ### Phase 6 - Cognitive Workflow Automation
 - `Zone-Cog: List Cognitive Workflows` — View all registered workflows

--- a/src/sql/workbench/services/zonecog/browser/hypergraphSemanticSearchService.ts
+++ b/src/sql/workbench/services/zonecog/browser/hypergraphSemanticSearchService.ts
@@ -1,0 +1,244 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from 'vs/base/common/lifecycle';
+import { Emitter, Event } from 'vs/base/common/event';
+import { ILogService } from 'vs/platform/log/common/log';
+import {
+	IHypergraphSemanticSearchService,
+	SemanticEmbeddingSource,
+	SemanticSearchResult
+} from 'sql/workbench/services/zonecog/common/hypergraphSemanticSearch';
+import { IAphroditeService } from 'sql/workbench/services/zonecog/common/aphrodite';
+import { IHypergraphStore, HypergraphNode, ICognitiveMembraneService } from 'sql/workbench/services/zonecog/common/zonecogService';
+
+/** Dimensionality of the deterministic local fallback embedding. */
+const LOCAL_EMBEDDING_DIM = 128;
+
+interface IndexEntry {
+	vector: number[];
+	contentHash: string;
+	source: SemanticEmbeddingSource;
+}
+
+/**
+ * FNV-1a 32-bit hash, used both for the local hashing-trick embedding and
+ * for cheap content-change detection.
+ */
+function fnv1a(text: string): number {
+	let hash = 0x811c9dc5;
+	for (let i = 0; i < text.length; i++) {
+		hash ^= text.charCodeAt(i);
+		hash = Math.imul(hash, 0x01000193);
+	}
+	return hash >>> 0;
+}
+
+function tokenize(text: string): string[] {
+	return text.toLowerCase().match(/[a-z0-9]+/g) ?? [];
+}
+
+function normalize(vector: number[]): number[] {
+	let norm = 0;
+	for (const x of vector) {
+		norm += x * x;
+	}
+	norm = Math.sqrt(norm);
+	if (norm === 0) {
+		return vector;
+	}
+	return vector.map(x => x / norm);
+}
+
+function cosineSimilarity(a: number[], b: number[]): number {
+	if (a.length !== b.length || a.length === 0) {
+		return 0;
+	}
+	let dot = 0, normA = 0, normB = 0;
+	for (let i = 0; i < a.length; i++) {
+		dot += a[i] * b[i];
+		normA += a[i] * a[i];
+		normB += b[i] * b[i];
+	}
+	if (normA === 0 || normB === 0) {
+		return 0;
+	}
+	return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+/**
+ * Deterministic bag-of-words embedding using the hashing trick. Requires no
+ * external service, so semantic search works out of the box; used whenever
+ * no Aphrodite engine is connected.
+ */
+function localEmbed(text: string): number[] {
+	const vector = new Array(LOCAL_EMBEDDING_DIM).fill(0);
+	for (const token of tokenize(text)) {
+		vector[fnv1a(token) % LOCAL_EMBEDDING_DIM] += 1;
+	}
+	return normalize(vector);
+}
+
+/**
+ * Text used to embed a hypergraph node: its type plus content, so searches
+ * can match on category ("TableNode users...") as well as content.
+ */
+function nodeEmbeddingText(node: HypergraphNode): string {
+	return `${node.node_type} ${node.content}`;
+}
+
+/**
+ * Implementation of the Hypergraph Semantic Search service.
+ *
+ * Maintains an in-memory embedding index over hypergraph nodes and ranks
+ * search queries by cosine similarity. Embeddings come from
+ * `IAphroditeService.embed()` when connected, otherwise from a deterministic
+ * local hashing-trick embedding. Index entries record which source produced
+ * them so a change in Aphrodite connection status triggers re-embedding
+ * instead of comparing incompatible vector spaces.
+ */
+export class HypergraphSemanticSearchService extends Disposable implements IHypergraphSemanticSearchService {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _index = new Map<string, IndexEntry>();
+
+	private readonly _onDidIndexNode = this._register(new Emitter<string>());
+	readonly onDidIndexNode: Event<string> = this._onDidIndexNode.event;
+
+	constructor(
+		@ILogService private readonly logService: ILogService,
+		@IHypergraphStore private readonly hypergraphStore: IHypergraphStore,
+		@ICognitiveMembraneService private readonly membraneService: ICognitiveMembraneService,
+		@IAphroditeService private readonly aphroditeService: IAphroditeService
+	) {
+		super();
+		// Node content changed: drop the stale entry so it is lazily
+		// re-embedded the next time it is indexed or searched.
+		this._register(this.hypergraphStore.onDidChangeNode(node => {
+			const entry = this._index.get(node.id);
+			if (entry && entry.contentHash !== this._contentHash(node)) {
+				this._index.delete(node.id);
+			}
+		}));
+		this.logService.info('HypergraphSemanticSearchService: initialized');
+	}
+
+	// -- Indexing ----------------------------------------------------------
+
+	async indexNode(nodeId: string): Promise<boolean> {
+		const node = this.hypergraphStore.getNode(nodeId);
+		if (!node) {
+			return false;
+		}
+		await this._ensureIndexed(node);
+		return true;
+	}
+
+	async indexAll(nodeTypes?: string[]): Promise<number> {
+		const nodes = nodeTypes && nodeTypes.length > 0
+			? nodeTypes.flatMap(type => this.hypergraphStore.getNodesByType(type))
+			: this.hypergraphStore.getAllNodes();
+
+		let indexed = 0;
+		for (const node of nodes) {
+			const before = this._index.get(node.id);
+			await this._ensureIndexed(node);
+			if (!before || before !== this._index.get(node.id)) {
+				indexed++;
+			}
+		}
+		this.logService.info(`HypergraphSemanticSearchService: indexed ${indexed}/${nodes.length} node(s)`);
+		return indexed;
+	}
+
+	// -- Search --------------------------------------------------------------
+
+	async search(query: string, topK: number = 10, nodeTypes?: string[]): Promise<SemanticSearchResult[]> {
+		this.membraneService.recordActivity('cerebral');
+
+		const candidates = nodeTypes && nodeTypes.length > 0
+			? nodeTypes.flatMap(type => this.hypergraphStore.getNodesByType(type))
+			: this.hypergraphStore.getAllNodes();
+
+		if (candidates.length === 0 || query.trim().length === 0) {
+			return [];
+		}
+
+		for (const node of candidates) {
+			await this._ensureIndexed(node);
+		}
+
+		const queryVector = await this._embed(query);
+		const results: SemanticSearchResult[] = [];
+		for (const node of candidates) {
+			const entry = this._index.get(node.id);
+			if (!entry) {
+				continue;
+			}
+			const score = cosineSimilarity(queryVector, entry.vector);
+			results.push({ node, score });
+		}
+
+		results.sort((a, b) => b.score - a.score);
+		return results.slice(0, Math.max(0, topK));
+	}
+
+	// -- Queries ---------------------------------------------------------------
+
+	isIndexed(nodeId: string): boolean {
+		const node = this.hypergraphStore.getNode(nodeId);
+		const entry = this._index.get(nodeId);
+		return !!node && !!entry && entry.contentHash === this._contentHash(node);
+	}
+
+	getIndexedCount(): number {
+		return this._index.size;
+	}
+
+	clear(): void {
+		this._index.clear();
+		this.logService.info('HypergraphSemanticSearchService: cleared semantic index');
+	}
+
+	// -- Internals ------------------------------------------------------------
+
+	private async _ensureIndexed(node: HypergraphNode): Promise<void> {
+		const contentHash = this._contentHash(node);
+		const source = this._currentSource();
+		const existing = this._index.get(node.id);
+		if (existing && existing.contentHash === contentHash && existing.source === source) {
+			return;
+		}
+
+		this.membraneService.recordActivity('cerebral');
+		const vector = await this._embed(nodeEmbeddingText(node));
+		this._index.set(node.id, { vector, contentHash, source });
+		this._onDidIndexNode.fire(node.id);
+	}
+
+	private _currentSource(): SemanticEmbeddingSource {
+		return this.aphroditeService.isConnected() ? 'aphrodite' : 'local';
+	}
+
+	private async _embed(text: string): Promise<number[]> {
+		if (this.aphroditeService.isConnected()) {
+			try {
+				const response = await this.aphroditeService.embed({ texts: [text] });
+				const vector = response.embeddings[0];
+				if (vector && vector.length > 0) {
+					return vector;
+				}
+			} catch (err) {
+				this.logService.warn(`HypergraphSemanticSearchService: Aphrodite embed() failed, falling back to local embedding: ${err instanceof Error ? err.message : String(err)}`);
+			}
+		}
+		return localEmbed(text);
+	}
+
+	private _contentHash(node: HypergraphNode): string {
+		return String(fnv1a(nodeEmbeddingText(node)));
+	}
+}

--- a/src/sql/workbench/services/zonecog/browser/zonecog.contribution.ts
+++ b/src/sql/workbench/services/zonecog/browser/zonecog.contribution.ts
@@ -53,6 +53,8 @@ import { CognitiveTraceService } from 'sql/workbench/services/zonecog/browser/co
 import { ISharedCognitionService } from 'sql/workbench/services/zonecog/common/sharedCognition';
 import { SharedCognitionService } from 'sql/workbench/services/zonecog/browser/sharedCognitionService';
 import { CognitiveAnalyticsService } from 'sql/workbench/services/zonecog/browser/cognitiveAnalyticsService';
+import { IHypergraphSemanticSearchService } from 'sql/workbench/services/zonecog/common/hypergraphSemanticSearch';
+import { HypergraphSemanticSearchService } from 'sql/workbench/services/zonecog/browser/hypergraphSemanticSearchService';
 
 // Register the Hypergraph store (dependency of ZoneCogService)
 registerSingleton(IHypergraphStore, HypergraphStore, InstantiationType.Eager);
@@ -157,3 +159,8 @@ registerSingleton(ICognitiveTraceService, CognitiveTraceService, InstantiationTy
 // Register the Shared Cognition service (multi-window shared hypergraph
 // state over a BroadcastChannel)
 registerSingleton(ISharedCognitionService, SharedCognitionService, InstantiationType.Eager);
+
+// Register the Hypergraph Semantic Search service (Aphrodite-embedding-backed
+// similarity search over hypergraph nodes, with a deterministic local
+// hashing-trick fallback when no Aphrodite engine is connected)
+registerSingleton(IHypergraphSemanticSearchService, HypergraphSemanticSearchService, InstantiationType.Eager);

--- a/src/sql/workbench/services/zonecog/common/hypergraphSemanticSearch.ts
+++ b/src/sql/workbench/services/zonecog/common/hypergraphSemanticSearch.ts
@@ -1,0 +1,77 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
+import { Event } from 'vs/base/common/event';
+import { HypergraphNode } from 'sql/workbench/services/zonecog/common/zonecogService';
+
+export const IHypergraphSemanticSearchService = createDecorator<IHypergraphSemanticSearchService>('hypergraphSemanticSearchService');
+
+/**
+ * The embedding source used to vectorize a piece of text.
+ * 'aphrodite' is used when `IAphroditeService.isConnected()`; a candidate
+ * set must be re-embedded on a source change so that queries and indexed
+ * vectors always compare like-for-like.
+ */
+export type SemanticEmbeddingSource = 'aphrodite' | 'local';
+
+/**
+ * A hypergraph node ranked by cosine similarity to a search query.
+ */
+export interface SemanticSearchResult {
+	node: HypergraphNode;
+	/** Cosine similarity in [-1, 1] (in practice [0, 1] for non-negative local vectors). */
+	score: number;
+}
+
+/**
+ * Hypergraph Semantic Search service.
+ *
+ * Closes the "Embedding Support — vector embeddings for hypergraph semantic
+ * search" item from the Aphrodite deep-integration plan (issue #53, 5.3):
+ * indexed hypergraph nodes are embedded via `IAphroditeService.embed()` when
+ * an Aphrodite engine is connected, falling back to a deterministic local
+ * hashing-trick bag-of-words embedding otherwise (works with no external
+ * dependency, mirroring the built-in rule-based LLM fallback). Search ranks
+ * nodes by cosine similarity to an embedded query string, going beyond the
+ * exact node-type / keyword matching `IHypergraphStore` and
+ * `IFederatedQueryService` provide.
+ */
+export interface IHypergraphSemanticSearchService {
+	readonly _serviceBrand: undefined;
+
+	/** Fired with the node id whenever a node is (re-)indexed. */
+	readonly onDidIndexNode: Event<string>;
+
+	/**
+	 * Embed and index a single hypergraph node. No-ops (returns false) if the
+	 * node does not exist. Returns true if the node was (re-)embedded or was
+	 * already up to date.
+	 */
+	indexNode(nodeId: string): Promise<boolean>;
+
+	/**
+	 * Embed and index every hypergraph node, optionally restricted to the
+	 * given node types. Returns the number of nodes indexed or refreshed.
+	 */
+	indexAll(nodeTypes?: string[]): Promise<number>;
+
+	/**
+	 * Embed `query` and rank indexed hypergraph nodes by cosine similarity.
+	 * Any matching node that is unindexed or stale is embedded first, so a
+	 * search always reflects current node content. Results are sorted by
+	 * descending score.
+	 */
+	search(query: string, topK?: number, nodeTypes?: string[]): Promise<SemanticSearchResult[]>;
+
+	/** Whether a node is currently indexed with an up-to-date embedding. */
+	isIndexed(nodeId: string): boolean;
+
+	/** Number of nodes currently indexed. */
+	getIndexedCount(): number;
+
+	/** Drop all indexed embeddings. */
+	clear(): void;
+}

--- a/src/sql/workbench/services/zonecog/common/hypergraphSemanticSearch.ts
+++ b/src/sql/workbench/services/zonecog/common/hypergraphSemanticSearch.ts
@@ -29,7 +29,7 @@ export interface SemanticSearchResult {
 /**
  * Hypergraph Semantic Search service.
  *
- * Closes the "Embedding Support — vector embeddings for hypergraph semantic
+ * Closes the "Embedding Support - vector embeddings for hypergraph semantic
  * search" item from the Aphrodite deep-integration plan (issue #53, 5.3):
  * indexed hypergraph nodes are embedded via `IAphroditeService.embed()` when
  * an Aphrodite engine is connected, falling back to a deterministic local

--- a/src/sql/workbench/services/zonecog/test/browser/hypergraphSemanticSearchService.test.ts
+++ b/src/sql/workbench/services/zonecog/test/browser/hypergraphSemanticSearchService.test.ts
@@ -1,0 +1,178 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { IHypergraphSemanticSearchService } from 'sql/workbench/services/zonecog/common/hypergraphSemanticSearch';
+import { HypergraphSemanticSearchService } from 'sql/workbench/services/zonecog/browser/hypergraphSemanticSearchService';
+import { IHypergraphStore, ICognitiveMembraneService, HypergraphNode } from 'sql/workbench/services/zonecog/common/zonecogService';
+import { HypergraphStore } from 'sql/workbench/services/zonecog/browser/hypergraphStore';
+import { CognitiveMembraneService } from 'sql/workbench/services/zonecog/browser/cognitiveMembraneService';
+import { IAphroditeService } from 'sql/workbench/services/zonecog/common/aphrodite';
+import { AphroditeService } from 'sql/workbench/services/zonecog/browser/aphroditeService';
+import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
+import { ILogService, NullLogService } from 'vs/platform/log/common/log';
+
+suite('Hypergraph Semantic Search Service Tests', () => {
+
+	let instantiationService: TestInstantiationService;
+	let searchService: IHypergraphSemanticSearchService;
+	let hypergraphStore: IHypergraphStore;
+
+	setup(() => {
+		instantiationService = new TestInstantiationService();
+		instantiationService.stub(ILogService, new NullLogService());
+
+		hypergraphStore = instantiationService.createInstance(HypergraphStore);
+		instantiationService.stub(IHypergraphStore, hypergraphStore);
+
+		const membraneService = instantiationService.createInstance(CognitiveMembraneService);
+		instantiationService.stub(ICognitiveMembraneService, membraneService);
+
+		const aphroditeService = instantiationService.createInstance(AphroditeService);
+		instantiationService.stub(IAphroditeService, aphroditeService);
+
+		searchService = instantiationService.createInstance(HypergraphSemanticSearchService);
+	});
+
+	function addNode(id: string, node_type: string, content: string): HypergraphNode {
+		hypergraphStore.addNode({ id, node_type, content, links: [], metadata: {}, salience_score: 0.5 });
+		return hypergraphStore.getNode(id)!;
+	}
+
+	// --- Indexing ---
+
+	test('should start with an empty index', () => {
+		assert.strictEqual(searchService.getIndexedCount(), 0);
+	});
+
+	test('indexNode should return false for an unknown node', async () => {
+		const result = await searchService.indexNode('missing');
+		assert.strictEqual(result, false);
+		assert.strictEqual(searchService.getIndexedCount(), 0);
+	});
+
+	test('indexNode should embed and index a known node', async () => {
+		addNode('n1', 'TableNode', 'Customer orders table with shipping address');
+		const result = await searchService.indexNode('n1');
+		assert.strictEqual(result, true);
+		assert.strictEqual(searchService.getIndexedCount(), 1);
+		assert.strictEqual(searchService.isIndexed('n1'), true);
+	});
+
+	test('indexNode should fire onDidIndexNode', async () => {
+		addNode('n1', 'TableNode', 'Customer orders table');
+		let fired: string | undefined;
+		searchService.onDidIndexNode(id => fired = id);
+
+		await searchService.indexNode('n1');
+		assert.strictEqual(fired, 'n1');
+	});
+
+	test('indexAll should index every node and return the count indexed', async () => {
+		addNode('n1', 'TableNode', 'Customer orders table');
+		addNode('n2', 'TableNode', 'Product inventory table');
+		addNode('n3', 'ThinkingPhase', 'Initial engagement phase');
+
+		const count = await searchService.indexAll();
+		assert.strictEqual(count, 3);
+		assert.strictEqual(searchService.getIndexedCount(), 3);
+	});
+
+	test('indexAll should restrict to the given node types', async () => {
+		addNode('n1', 'TableNode', 'Customer orders table');
+		addNode('n2', 'ThinkingPhase', 'Initial engagement phase');
+
+		const count = await searchService.indexAll(['TableNode']);
+		assert.strictEqual(count, 1);
+		assert.strictEqual(searchService.isIndexed('n1'), true);
+		assert.strictEqual(searchService.isIndexed('n2'), false);
+	});
+
+	test('indexAll should not re-embed unchanged nodes on a second pass', async () => {
+		addNode('n1', 'TableNode', 'Customer orders table');
+		assert.strictEqual(await searchService.indexAll(), 1);
+		assert.strictEqual(await searchService.indexAll(), 0);
+	});
+
+	test('a node content change should invalidate its index entry', async () => {
+		addNode('n1', 'TableNode', 'Customer orders table');
+		await searchService.indexNode('n1');
+		assert.strictEqual(searchService.isIndexed('n1'), true);
+
+		hypergraphStore.updateNode('n1', { content: 'Completely different content' });
+		assert.strictEqual(searchService.isIndexed('n1'), false);
+	});
+
+	// --- Search ---
+
+	test('search should return an empty array against an empty hypergraph', async () => {
+		const results = await searchService.search('orders');
+		assert.deepStrictEqual(results, []);
+	});
+
+	test('search should return an empty array for a blank query', async () => {
+		addNode('n1', 'TableNode', 'Customer orders table');
+		const results = await searchService.search('   ');
+		assert.deepStrictEqual(results, []);
+	});
+
+	test('search should rank a lexically closer node higher', async () => {
+		addNode('n1', 'TableNode', 'Customer orders and shipping addresses');
+		addNode('n2', 'TableNode', 'Employee payroll and tax withholding');
+
+		const results = await searchService.search('customer shipping orders');
+		assert.ok(results.length >= 1);
+		assert.strictEqual(results[0].node.id, 'n1');
+		assert.ok(results[0].score > 0);
+	});
+
+	test('search should auto-index unindexed matching nodes', async () => {
+		addNode('n1', 'TableNode', 'Customer orders table');
+		assert.strictEqual(searchService.getIndexedCount(), 0);
+
+		await searchService.search('orders');
+		assert.strictEqual(searchService.getIndexedCount(), 1);
+	});
+
+	test('search should honor topK', async () => {
+		for (let i = 0; i < 5; i++) {
+			addNode(`n${i}`, 'TableNode', `Orders table variant ${i}`);
+		}
+		const results = await searchService.search('orders', 2);
+		assert.strictEqual(results.length, 2);
+	});
+
+	test('search should restrict candidates to the given node types', async () => {
+		addNode('n1', 'TableNode', 'Orders table');
+		addNode('n2', 'ThinkingPhase', 'Orders discussion phase');
+
+		const results = await searchService.search('orders', 10, ['TableNode']);
+		assert.strictEqual(results.length, 1);
+		assert.strictEqual(results[0].node.id, 'n1');
+	});
+
+	test('search results should be sorted by descending score', async () => {
+		addNode('n1', 'TableNode', 'orders orders orders shipping');
+		addNode('n2', 'TableNode', 'orders shipping unrelated content here');
+		addNode('n3', 'TableNode', 'completely unrelated payroll tax data');
+
+		const results = await searchService.search('orders shipping');
+		for (let i = 1; i < results.length; i++) {
+			assert.ok(results[i - 1].score >= results[i].score);
+		}
+	});
+
+	// --- Lifecycle ---
+
+	test('clear should drop the entire index', async () => {
+		addNode('n1', 'TableNode', 'Customer orders table');
+		await searchService.indexAll();
+		assert.strictEqual(searchService.getIndexedCount(), 1);
+
+		searchService.clear();
+		assert.strictEqual(searchService.getIndexedCount(), 0);
+		assert.strictEqual(searchService.isIndexed('n1'), false);
+	});
+});


### PR DESCRIPTION
## Description

Proceeds with the next open item on the ZoneCog roadmap (`docs/ZONECOG_ROADMAP.md`, Phase 3.4: Knowledge Graph Enhancement) and the Aphrodite deep-integration plan from issue #53 (§5.3): **Embedding Support — vector embeddings for hypergraph semantic search**. `IAphroditeService.embed()` already existed and posted to `/v1/embeddings`, but nothing in the codebase consumed it — there was no way to search the hypergraph by meaning rather than exact node type / keyword match.

- New `IHypergraphSemanticSearchService` / `HypergraphSemanticSearchService` (`common/hypergraphSemanticSearch.ts`, `browser/hypergraphSemanticSearchService.ts`):
  - Embeds a node's `node_type + content` via `IAphroditeService.embed()` when an Aphrodite engine is connected, falling back to a deterministic local hashing-trick (FNV-1a) bag-of-words embedding otherwise — so semantic search works out of the box with no external dependency, mirroring the existing built-in rule-based LLM fallback (Phase 3.1).
  - `indexNode(id)` / `indexAll(nodeTypes?)` embed and cache vectors, tagged with the embedding source so a change in Aphrodite connection status triggers re-embedding instead of comparing incompatible vector spaces.
  - `search(query, topK?, nodeTypes?)` embeds the query, lazily (re-)indexes any stale/unindexed candidate nodes, and ranks by cosine similarity.
  - A node content change (`IHypergraphStore.onDidChangeNode`) invalidates its cached vector for lazy re-embedding on next index/search.
  - Registered as an eager singleton in `zonecog.contribution.ts`.
- Two new Command Palette actions in `zonecogActions.contribution.ts`: `Zone-Cog: Index Hypergraph for Semantic Search` and `Zone-Cog: Semantic Search Hypergraph`.
- `docs/ZONECOG_ROADMAP.md` and `src/sql/workbench/services/zonecog/README.md` updated to reflect the new service and commands.

This is additive only — no existing service, contribution, or view is modified beyond the two new registration lines.

## Code Changes Checklist

- [x] New or updated **unit tests** added — `test/browser/hypergraphSemanticSearchService.test.ts` (indexing, `onDidIndexNode`, `indexAll` with/without type filter and re-embed skipping, invalidation on node content change, empty/blank-query search, ranking, `topK`, node-type filtering, sort order, `clear`), modeled on the existing `schemaEvolutionService.test.ts` `TestInstantiationService` pattern.
- [ ] All existing tests pass (`npm run test`) — this environment's outbound network access blocks the full `yarn install` needed to run the real Mocha suite (GitHub codeload dependency fetch returns 403 through the proxy). Verified instead via `tsc --noEmit` against a reconstruction of `src/tsconfig.json`'s compiler options (manually installed `typescript`, `@types/mocha`, `@types/sinon`, `@types/node` from the npm registry, which is reachable): zero errors attributed to any of the five changed/new files; all remaining errors are pre-existing ambient-typing gaps from omitting unrelated parts of the real project (e.g. `AMDLoader`/`Thenable` globals normally supplied via `src/typings`), not introduced by this change.
- [x] Code follows [contributing guidelines](https://github.com/microsoft/azuredatastudio/blob/main/CONTRIBUTING.md) — mirrors the existing `ISchemaEvolutionService`/`SchemaEvolutionService` service pattern (`createDecorator` in `common/`, `Disposable` impl in `browser/`, `registerSingleton(..., InstantiationType.Eager)`, `Emitter`/`Event`, membrane activity recording via `ICognitiveMembraneService.recordActivity('cerebral')`).
- [x] No UI regressions introduced — additive only; no existing files' behavior changed.
- [x] Logging/telemetry updated if applicable — uses `ILogService`, consistent with sibling services.
- [x] Cross-platform support checked (Windows, macOS, Linux if relevant) — pure TypeScript, no platform-specific code.

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/azuredatastudio/blob/main/.github/REVIEW_GUIDELINES.md)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vsk99zEqYppf3tcX5jkVmV)_