### PR TITLE
fix(zonecog): repair merge corruption + add collaborative reasoning sessions (Phase 4.4)

### DIFF
--- a/docs/ZONECOG_ROADMAP.md
+++ b/docs/ZONECOG_ROADMAP.md
@@ -2,7 +2,7 @@
 
 **Ticket**: ECH-4  
 **Status**: Active  
-**Last Updated**: 2026-07-19
+**Last Updated**: 2026-07-21
 
 ## Phase Overview
 
@@ -204,7 +204,7 @@
 ### 4.4 Collaborative Cognition
 - [ ] Multi-user cognitive workspaces — same-machine multi-window sharing landed via `ISharedCognitionService`; true multi-user across machines requires a sync backend (future work)
 - [x] Shared hypergraph state — `ISharedCognitionService`/`SharedCognitionService` (BroadcastChannel sync of hypergraph node/link upserts across workbench windows with hello handshake and echo suppression; cross-machine sharing remains future work)
-- [ ] Collaborative reasoning sessions — foundation in place (shared hypergraph sessions + trace replay); live multi-user co-reasoning requires a sync backend (future work)
+- [x] Collaborative reasoning sessions — `ICollaborativeReasoningService`/`CollaborativeReasoningService` (same-machine multi-window live broadcast of this window's `onDidCompleteThinkingPhase` stream over a BroadcastChannel, merged into a unified transcript alongside peer phases, plus shareable annotations attached to any phase; "Toggle Collaborative Reasoning Session", "Show Collaborative Session Log", and "Annotate Latest Collaborative Phase" commands); true multi-user co-reasoning across machines requires a sync backend (future work)
 - [x] Cognitive trace sharing and replay — `ICognitiveTraceService`/`CognitiveTraceService` (session trace recording, versioned JSON export/import via clipboard, phase-by-phase replay rendered in the Thinking Process view)
 
 ---

--- a/src/sql/workbench/contrib/zonecog/browser/zonecogActions.contribution.ts
+++ b/src/sql/workbench/contrib/zonecog/browser/zonecogActions.contribution.ts
@@ -39,6 +39,7 @@ import { ISensorimotorBindingService } from 'sql/workbench/services/zonecog/comm
 import { ICognitiveAnalyticsService } from 'sql/workbench/services/zonecog/common/cognitiveAnalytics';
 import { IFederatedQueryService } from 'sql/workbench/services/zonecog/common/federatedQuery';
 import { IHypergraphSemanticSearchService } from 'sql/workbench/services/zonecog/common/hypergraphSemanticSearch';
+import { ICollaborativeReasoningService, CollaborativePhaseEvent } from 'sql/workbench/services/zonecog/common/collaborativeReasoning';
 
 const ZONECOG_CATEGORY = { value: localize('zonecog.category', 'Zone-Cog'), original: 'Zone-Cog' };
 
@@ -2406,28 +2407,6 @@ class ZoneCogToggleFederatedQueryAction extends Action2 {
 			title: { value: localize('zonecog.toggleFederatedQuery', 'Toggle Federated Query Session'), original: 'Toggle Federated Query Session' },
 			category: ZONECOG_CATEGORY,
 			icon: Codicon.broadcast,
- * Action to toggle the DTESN sensorimotor binding loop (Phase 5.4).
- */
-class ZoneCogToggleSensorimotorBindingAction extends Action2 {
-
-	static ID = 'zonecog.toggleSensorimotorBinding';
-	constructor() {
-		super({
-			id: ZoneCogToggleSensorimotorBindingAction.ID,
-			title: { value: localize('zonecog.toggleSensorimotorBinding', 'Toggle DTESN Sensorimotor Binding'), original: 'Toggle DTESN Sensorimotor Binding' },
-			category: ZONECOG_CATEGORY,
-			icon: Codicon.pulse,
- * Action to index the hypergraph for semantic search
- */
-class ZoneCogIndexSemanticSearchAction extends Action2 {
-
-	static ID = 'zonecog.indexSemanticSearch';
-	constructor() {
-		super({
-			id: ZoneCogIndexSemanticSearchAction.ID,
-			title: { value: localize('zonecog.indexSemanticSearch', 'Index Hypergraph for Semantic Search'), original: 'Index Hypergraph for Semantic Search' },
-			category: ZONECOG_CATEGORY,
-			icon: Codicon.search,
 			f1: true,
 			menu: { id: MenuId.CommandPalette },
 		});
@@ -2467,55 +2446,6 @@ class ZoneCogFederatedQueryAction extends Action2 {
 		super({
 			id: ZoneCogFederatedQueryAction.ID,
 			title: { value: localize('zonecog.federatedQuery', 'Run Federated Hypergraph Query'), original: 'Run Federated Hypergraph Query' },
-		const bindingService = accessor.get(ISensorimotorBindingService);
-		const notificationService = accessor.get(INotificationService);
-
-		if (bindingService.getState().active) {
-			bindingService.stop();
-			const state = bindingService.getState();
-			notificationService.info(localize('zonecog.sensorimotorStopped',
-				'DTESN sensorimotor binding stopped ({0} percept(s) encoded, {1} motor action(s) emitted).',
-				state.perceptsEncoded, state.actionsEmitted));
-		} else {
-			bindingService.start();
-			notificationService.info(localize('zonecog.sensorimotorStarted',
-				'DTESN sensorimotor binding started - workspace percepts now drive the Deep Tree Echo State Network.'));
-		}
-	}
-}
-
-/**
- * Action to show DTESN sensorimotor binding status (Phase 5.4).
- */
-class ZoneCogSensorimotorStatusAction extends Action2 {
-
-	static ID = 'zonecog.sensorimotorStatus';
-	constructor() {
-		super({
-			id: ZoneCogSensorimotorStatusAction.ID,
-			title: { value: localize('zonecog.sensorimotorStatus', 'Show DTESN Sensorimotor Binding Status'), original: 'Show DTESN Sensorimotor Binding Status' },
-			category: ZONECOG_CATEGORY,
-			icon: Codicon.pulse,
-		const searchService = accessor.get(IHypergraphSemanticSearchService);
-		const notificationService = accessor.get(INotificationService);
-
-		const indexed = await searchService.indexAll();
-		notificationService.info(localize('zonecog.indexSemanticSearchDone',
-			'Indexed {0} hypergraph node(s) for semantic search ({1} total in index).',
-			indexed, searchService.getIndexedCount()));
-	}
-}
-
-/**
- * Action to run a semantic search over the hypergraph
- */
-class ZoneCogSemanticSearchAction extends Action2 {
-
-	static ID = 'zonecog.semanticSearch';
-	constructor() {
-		super({
-			id: ZoneCogSemanticSearchAction.ID,
-			title: { value: localize('zonecog.semanticSearch', 'Semantic Search Hypergraph'), original: 'Semantic Search Hypergraph' },
 			category: ZONECOG_CATEGORY,
 			icon: Codicon.search,
 			f1: true,
@@ -2553,16 +2483,55 @@ class ZoneCogSemanticSearchAction extends Action2 {
 			notificationService.info(localize('zonecog.federatedLocalOnly',
 				'No federated query session is active, so only this window was searched. Start one with "Toggle Federated Query Session" to include other windows.'));
 		}
-		const bindingService = accessor.get(ISensorimotorBindingService);
+	}
+}
+
+/**
+ * Action to index the hypergraph for semantic search
+ */
+class ZoneCogIndexSemanticSearchAction extends Action2 {
+
+	static ID = 'zonecog.indexSemanticSearch';
+	constructor() {
+		super({
+			id: ZoneCogIndexSemanticSearchAction.ID,
+			title: { value: localize('zonecog.indexSemanticSearch', 'Index Hypergraph for Semantic Search'), original: 'Index Hypergraph for Semantic Search' },
+			category: ZONECOG_CATEGORY,
+			icon: Codicon.search,
+			f1: true,
+			menu: { id: MenuId.CommandPalette },
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const searchService = accessor.get(IHypergraphSemanticSearchService);
 		const notificationService = accessor.get(INotificationService);
 
-		const state = bindingService.getState();
-		notificationService.info(localize('zonecog.sensorimotorStatusInfo',
-			'Sensorimotor Binding: {0} | Percepts encoded: {1} | Actions emitted: {2} | Feedback samples: {3} | Training runs: {4} | Last MSE: {5} | Confidence threshold: {6}',
-			state.active ? localize('zonecog.sensorimotorActive', 'ACTIVE') : localize('zonecog.sensorimotorInactive', 'INACTIVE'),
-			state.perceptsEncoded, state.actionsEmitted, state.feedbackSamples, state.trainingRuns,
-			state.lastTrainingMse === null ? localize('zonecog.sensorimotorNoTraining', 'n/a') : state.lastTrainingMse.toFixed(6),
-			state.confidenceThreshold.toFixed(2)));
+		const indexed = await searchService.indexAll();
+		notificationService.info(localize('zonecog.indexSemanticSearchDone',
+			'Indexed {0} hypergraph node(s) for semantic search ({1} total in index).',
+			indexed, searchService.getIndexedCount()));
+	}
+}
+
+/**
+ * Action to run a semantic search over the hypergraph
+ */
+class ZoneCogSemanticSearchAction extends Action2 {
+
+	static ID = 'zonecog.semanticSearch';
+	constructor() {
+		super({
+			id: ZoneCogSemanticSearchAction.ID,
+			title: { value: localize('zonecog.semanticSearch', 'Semantic Search Hypergraph'), original: 'Semantic Search Hypergraph' },
+			category: ZONECOG_CATEGORY,
+			icon: Codicon.search,
+			f1: true,
+			menu: { id: MenuId.CommandPalette },
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
 		const searchService = accessor.get(IHypergraphSemanticSearchService);
 		const hypergraphStore = accessor.get(IHypergraphStore);
 		const notificationService = accessor.get(INotificationService);
@@ -2595,6 +2564,200 @@ class ZoneCogSemanticSearchAction extends Action2 {
 	}
 }
 
+/**
+ * Action to toggle the DTESN sensorimotor binding loop (Phase 5.4).
+ */
+class ZoneCogToggleSensorimotorBindingAction extends Action2 {
+
+	static ID = 'zonecog.toggleSensorimotorBinding';
+	constructor() {
+		super({
+			id: ZoneCogToggleSensorimotorBindingAction.ID,
+			title: { value: localize('zonecog.toggleSensorimotorBinding', 'Toggle DTESN Sensorimotor Binding'), original: 'Toggle DTESN Sensorimotor Binding' },
+			category: ZONECOG_CATEGORY,
+			icon: Codicon.pulse,
+			f1: true,
+			menu: { id: MenuId.CommandPalette },
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const bindingService = accessor.get(ISensorimotorBindingService);
+		const notificationService = accessor.get(INotificationService);
+
+		if (bindingService.getState().active) {
+			bindingService.stop();
+			const state = bindingService.getState();
+			notificationService.info(localize('zonecog.sensorimotorStopped',
+				'DTESN sensorimotor binding stopped ({0} percept(s) encoded, {1} motor action(s) emitted).',
+				state.perceptsEncoded, state.actionsEmitted));
+		} else {
+			bindingService.start();
+			notificationService.info(localize('zonecog.sensorimotorStarted',
+				'DTESN sensorimotor binding started - workspace percepts now drive the Deep Tree Echo State Network.'));
+		}
+	}
+}
+
+/**
+ * Action to show DTESN sensorimotor binding status (Phase 5.4).
+ */
+class ZoneCogSensorimotorStatusAction extends Action2 {
+
+	static ID = 'zonecog.sensorimotorStatus';
+	constructor() {
+		super({
+			id: ZoneCogSensorimotorStatusAction.ID,
+			title: { value: localize('zonecog.sensorimotorStatus', 'Show DTESN Sensorimotor Binding Status'), original: 'Show DTESN Sensorimotor Binding Status' },
+			category: ZONECOG_CATEGORY,
+			icon: Codicon.pulse,
+			f1: true,
+			menu: { id: MenuId.CommandPalette },
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const bindingService = accessor.get(ISensorimotorBindingService);
+		const notificationService = accessor.get(INotificationService);
+
+		const state = bindingService.getState();
+		notificationService.info(localize('zonecog.sensorimotorStatusInfo',
+			'Sensorimotor Binding: {0} | Percepts encoded: {1} | Actions emitted: {2} | Feedback samples: {3} | Training runs: {4} | Last MSE: {5} | Confidence threshold: {6}',
+			state.active ? localize('zonecog.sensorimotorActive', 'ACTIVE') : localize('zonecog.sensorimotorInactive', 'INACTIVE'),
+			state.perceptsEncoded, state.actionsEmitted, state.feedbackSamples, state.trainingRuns,
+			state.lastTrainingMse === null ? localize('zonecog.sensorimotorNoTraining', 'n/a') : state.lastTrainingMse.toFixed(6),
+			state.confidenceThreshold.toFixed(2)));
+	}
+}
+
+/**
+ * Action to toggle the collaborative reasoning session (multi-window live
+ * thinking-phase broadcast and shared transcript).
+ */
+class ZoneCogToggleCollaborativeReasoningAction extends Action2 {
+
+	static ID = 'zonecog.toggleCollaborativeReasoning';
+	constructor() {
+		super({
+			id: ZoneCogToggleCollaborativeReasoningAction.ID,
+			title: { value: localize('zonecog.toggleCollaborativeReasoning', 'Toggle Collaborative Reasoning Session'), original: 'Toggle Collaborative Reasoning Session' },
+			category: ZONECOG_CATEGORY,
+			icon: Codicon.commentDiscussion,
+			f1: true,
+			menu: { id: MenuId.CommandPalette },
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const collaborativeService = accessor.get(ICollaborativeReasoningService);
+		const notificationService = accessor.get(INotificationService);
+
+		const state = collaborativeService.getState();
+		if (state.active) {
+			collaborativeService.stopSession();
+			notificationService.info(localize('zonecog.collaborativeStopped',
+				'Collaborative reasoning session stopped ({0} phase(s) sent, {1} received from {2} peer(s)).',
+				state.phasesSent, state.phasesReceived, state.knownPeers.length));
+			return;
+		}
+
+		if (collaborativeService.startSession()) {
+			notificationService.info(localize('zonecog.collaborativeStarted',
+				'Collaborative reasoning session started - this window\'s thinking phases now stream to other workbench windows that join.'));
+		} else {
+			notificationService.error(localize('zonecog.collaborativeUnavailable',
+				'Collaborative reasoning is unavailable: BroadcastChannel is not supported in this environment.'));
+		}
+	}
+}
+
+/**
+ * Action to show the collaborative reasoning session transcript (own and
+ * peer thinking phases and annotations).
+ */
+class ZoneCogShowCollaborativeSessionLogAction extends Action2 {
+
+	static ID = 'zonecog.showCollaborativeSessionLog';
+	constructor() {
+		super({
+			id: ZoneCogShowCollaborativeSessionLogAction.ID,
+			title: { value: localize('zonecog.showCollaborativeSessionLog', 'Show Collaborative Session Log'), original: 'Show Collaborative Session Log' },
+			category: ZONECOG_CATEGORY,
+			icon: Codicon.commentDiscussion,
+			f1: true,
+			menu: { id: MenuId.CommandPalette },
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const collaborativeService = accessor.get(ICollaborativeReasoningService);
+		const notificationService = accessor.get(INotificationService);
+
+		const log = collaborativeService.getSessionLog();
+		if (log.length === 0) {
+			notificationService.info(localize('zonecog.collaborativeLogEmpty',
+				'Collaborative session transcript is empty. Start a session and process a query to populate it.'));
+			return;
+		}
+
+		const state = collaborativeService.getState();
+		const lines = log.slice(-20).map(entry => {
+			const who = entry.event.peerId === state.peerId ? 'you' : `peer ${entry.event.peerId.substring(0, 8)}`;
+			if (entry.kind === 'phase') {
+				return `  [${who}] ${entry.event.phase.name} (query #${entry.event.querySeq}${entry.event.query ? `: "${entry.event.query}"` : ''})`;
+			}
+			return `  [${who} -> ${entry.event.targetPeerId.substring(0, 8)}] note on "${entry.event.targetPhaseName}": ${entry.event.text}`;
+		}).join('\n');
+
+		notificationService.info(localize('zonecog.collaborativeLog',
+			'Collaborative Session Log (last {0} of {1} entries):\n{2}', Math.min(20, log.length), log.length, lines));
+	}
+}
+
+/**
+ * Action to annotate the most recent phase in the collaborative session
+ * transcript (own or a peer's).
+ */
+class ZoneCogAnnotateCollaborativePhaseAction extends Action2 {
+
+	static ID = 'zonecog.annotateCollaborativePhase';
+	constructor() {
+		super({
+			id: ZoneCogAnnotateCollaborativePhaseAction.ID,
+			title: { value: localize('zonecog.annotateCollaborativePhase', 'Annotate Latest Collaborative Phase'), original: 'Annotate Latest Collaborative Phase' },
+			category: ZONECOG_CATEGORY,
+			icon: Codicon.comment,
+			f1: true,
+			menu: { id: MenuId.CommandPalette },
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const collaborativeService = accessor.get(ICollaborativeReasoningService);
+		const notificationService = accessor.get(INotificationService);
+		const quickInputService = accessor.get(IQuickInputService);
+
+		const log = collaborativeService.getSessionLog();
+		const lastPhase = [...log].reverse().find((entry): entry is { kind: 'phase'; event: CollaborativePhaseEvent } => entry.kind === 'phase');
+		if (!lastPhase) {
+			notificationService.info(localize('zonecog.annotateNoPhase',
+				'No collaborative phase to annotate yet. Start a session and process a query first.'));
+			return;
+		}
+
+		const text = await quickInputService.input({
+			prompt: localize('zonecog.annotatePrompt', 'Annotation for "{0}" (query #{1})', lastPhase.event.phase.name, lastPhase.event.querySeq),
+		});
+		if (!text || text.trim().length === 0) {
+			return;
+		}
+
+		collaborativeService.postAnnotation(lastPhase.event.peerId, lastPhase.event.querySeq, lastPhase.event.phase.name, text);
+		notificationService.info(localize('zonecog.annotateDone',
+			'Annotation shared on "{0}".', lastPhase.event.phase.name));
+	}
+}
+
 // Phase 4 completion actions
 registerAction2(ZoneCogConversationalExplorationAction);
 registerAction2(ZoneCogSchemaDesignAssistantAction);
@@ -2610,6 +2773,11 @@ registerAction2(ZoneCogSemanticSearchAction);
 // Phase 5.4 DTESN sensorimotor binding actions
 registerAction2(ZoneCogToggleSensorimotorBindingAction);
 registerAction2(ZoneCogSensorimotorStatusAction);
+
+// Phase 4.4 collaborative reasoning session actions
+registerAction2(ZoneCogToggleCollaborativeReasoningAction);
+registerAction2(ZoneCogShowCollaborativeSessionLogAction);
+registerAction2(ZoneCogAnnotateCollaborativePhaseAction);
 
 // Register the cognitive loop status bar contribution so the loop state is
 // always visible in the workbench status bar.

--- a/src/sql/workbench/services/zonecog/README.md
+++ b/src/sql/workbench/services/zonecog/README.md
@@ -330,6 +330,9 @@ Available through Command Palette (`Ctrl+Shift+P`):
 - `Zone-Cog: Toggle Shared Cognition Session` — Sync hypergraph node/link upserts with other workbench windows on this machine
 - `Zone-Cog: Toggle Federated Query Session` — Join same-machine query federation so hypergraph queries also search other windows
 - `Zone-Cog: Run Federated Hypergraph Query` — Search this window (and any joined peer windows) by keyword/type/salience
+- `Zone-Cog: Toggle Collaborative Reasoning Session` — Stream this window's thinking phases live to other workbench windows on this machine and merge peer phases into a unified transcript
+- `Zone-Cog: Show Collaborative Session Log` — View the merged transcript of own and peer thinking phases and annotations
+- `Zone-Cog: Annotate Latest Collaborative Phase` — Attach a shared remark to the most recent phase in the transcript (own or a peer's)
 
 ## Panel Views
 

--- a/src/sql/workbench/services/zonecog/browser/collaborativeReasoningService.ts
+++ b/src/sql/workbench/services/zonecog/browser/collaborativeReasoningService.ts
@@ -1,0 +1,274 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import {
+	ICollaborativeReasoningService,
+	CollaborativeReasoningState,
+	CollaborativePhaseEvent,
+	CollaborativeAnnotation,
+	CollaborativeSessionEntry
+} from 'sql/workbench/services/zonecog/common/collaborativeReasoning';
+import { IZoneCogService, ICognitiveMembraneService, ThinkingPhase } from 'sql/workbench/services/zonecog/common/zonecogService';
+import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
+import { Emitter, Event } from 'vs/base/common/event';
+import { ILogService } from 'vs/platform/log/common/log';
+import { generateUuid } from 'vs/base/common/uuid';
+
+/** Channel name shared by all participating workbench windows. */
+const CHANNEL_NAME = 'zonecog-collaborative-reasoning';
+
+/** Name of the phase that always starts a new query (see ZONECOG.md protocol). */
+const QUERY_START_PHASE = 'Initial Engagement';
+
+/** Bound on the retained transcript so a long-running session cannot grow unbounded. */
+const MAX_LOG_ENTRIES = 500;
+
+/** Minimal channel surface so tests can substitute a fake transport. */
+export interface ICollaborativeReasoningChannel {
+	postMessage(message: unknown): void;
+	close(): void;
+	onmessage: ((event: { data: unknown }) => void) | null;
+}
+
+interface HelloMessage { type: 'hello'; peerId: string; reply: boolean }
+interface PhaseMessage { type: 'phase'; peerId: string; querySeq: number; query: string; phase: ThinkingPhase }
+interface AnnotationMessage {
+	type: 'annotation';
+	peerId: string;
+	targetPeerId: string;
+	targetQuerySeq: number;
+	targetPhaseName: string;
+	text: string;
+	timestamp: number;
+}
+type CollaborativeReasoningMessage = HelloMessage | PhaseMessage | AnnotationMessage;
+
+/**
+ * Implementation of the collaborative reasoning service.
+ *
+ * Broadcasts this window's live thinking phases to same-machine peer
+ * windows over a BroadcastChannel and merges every participant's phases and
+ * annotations into one unified transcript.
+ */
+export class CollaborativeReasoningService extends Disposable implements ICollaborativeReasoningService {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _peerId = generateUuid();
+	private readonly _knownPeers = new Set<string>();
+	private _channel: ICollaborativeReasoningChannel | undefined;
+	private _sessionDisposables: DisposableStore | undefined;
+	private _querySeq = 0;
+	private _currentQuery = '';
+	private _log: CollaborativeSessionEntry[] = [];
+	private _phasesSent = 0;
+	private _phasesReceived = 0;
+	private _annotationsSent = 0;
+	private _annotationsReceived = 0;
+
+	private readonly _onDidReceivePhase = this._register(new Emitter<CollaborativePhaseEvent>());
+	readonly onDidReceivePhase: Event<CollaborativePhaseEvent> = this._onDidReceivePhase.event;
+
+	private readonly _onDidReceiveAnnotation = this._register(new Emitter<CollaborativeAnnotation>());
+	readonly onDidReceiveAnnotation: Event<CollaborativeAnnotation> = this._onDidReceiveAnnotation.event;
+
+	private readonly _onDidChangeSessionState = this._register(new Emitter<CollaborativeReasoningState>());
+	readonly onDidChangeSessionState: Event<CollaborativeReasoningState> = this._onDidChangeSessionState.event;
+
+	constructor(
+		@ILogService private readonly logService: ILogService,
+		@IZoneCogService private readonly zoneCogService: IZoneCogService,
+		@ICognitiveMembraneService private readonly membraneService: ICognitiveMembraneService
+	) {
+		super();
+	}
+
+	// -- Session lifecycle -----------------------------------------------------------
+
+	startSession(): boolean {
+		if (this._channel) {
+			return true;
+		}
+		const channel = this._createChannel(CHANNEL_NAME);
+		if (!channel) {
+			this.logService.warn('CollaborativeReasoningService: BroadcastChannel unavailable, cannot start collaborative session');
+			return false;
+		}
+		this.membraneService.recordActivity('somatic');
+		this._channel = channel;
+		channel.onmessage = event => this._onMessage(event.data);
+
+		this._sessionDisposables = new DisposableStore();
+		this._sessionDisposables.add(this.zoneCogService.onDidCompleteThinkingPhase(phase => this._onLocalPhase(phase)));
+
+		this._post({ type: 'hello', peerId: this._peerId, reply: false });
+		this.logService.info(`CollaborativeReasoningService: collaborative reasoning session started (peer ${this._peerId})`);
+		this._onDidChangeSessionState.fire(this.getState());
+		return true;
+	}
+
+	stopSession(): void {
+		if (!this._channel) {
+			return;
+		}
+		this._sessionDisposables?.dispose();
+		this._sessionDisposables = undefined;
+		this._channel.onmessage = null;
+		this._channel.close();
+		this._channel = undefined;
+		this.logService.info('CollaborativeReasoningService: collaborative reasoning session stopped');
+		this._onDidChangeSessionState.fire(this.getState());
+	}
+
+	getState(): CollaborativeReasoningState {
+		return {
+			active: this._channel !== undefined,
+			peerId: this._peerId,
+			knownPeers: Array.from(this._knownPeers),
+			phasesSent: this._phasesSent,
+			phasesReceived: this._phasesReceived,
+			annotationsSent: this._annotationsSent,
+			annotationsReceived: this._annotationsReceived
+		};
+	}
+
+	postAnnotation(targetPeerId: string, targetQuerySeq: number, targetPhaseName: string, text: string): void {
+		const trimmed = text.trim();
+		if (!trimmed) {
+			return;
+		}
+		const annotation: CollaborativeAnnotation = {
+			peerId: this._peerId,
+			targetPeerId,
+			targetQuerySeq,
+			targetPhaseName,
+			text: trimmed,
+			timestamp: Date.now()
+		};
+		this._appendLog({ kind: 'annotation', event: annotation });
+		this._annotationsSent++;
+		this._onDidReceiveAnnotation.fire(annotation);
+		this._post({ type: 'annotation', ...annotation });
+	}
+
+	getSessionLog(): CollaborativeSessionEntry[] {
+		return [...this._log];
+	}
+
+	clear(): void {
+		this._log = [];
+	}
+
+	override dispose(): void {
+		this.stopSession();
+		super.dispose();
+	}
+
+	// -- Local phase capture ----------------------------------------------------------
+
+	private _onLocalPhase(phase: ThinkingPhase): void {
+		if (phase.name === QUERY_START_PHASE) {
+			this._querySeq++;
+			const history = this.zoneCogService.getQueryHistory();
+			this._currentQuery = history.length > 0 ? history[history.length - 1].query : '';
+		}
+		const event: CollaborativePhaseEvent = {
+			peerId: this._peerId,
+			querySeq: this._querySeq,
+			query: this._currentQuery,
+			phase
+		};
+		this._appendLog({ kind: 'phase', event });
+		this._phasesSent++;
+		this._onDidReceivePhase.fire(event);
+		this._post({ type: 'phase', peerId: this._peerId, querySeq: this._querySeq, query: this._currentQuery, phase });
+	}
+
+	// -- Transport ------------------------------------------------------------------------
+
+	/**
+	 * Create the underlying channel. Overridable so tests can substitute a
+	 * fake transport; returns undefined when BroadcastChannel is unavailable.
+	 */
+	protected _createChannel(name: string): ICollaborativeReasoningChannel | undefined {
+		if (typeof BroadcastChannel === 'undefined') {
+			return undefined;
+		}
+		const raw = new BroadcastChannel(name);
+		const adapter: ICollaborativeReasoningChannel = {
+			postMessage: message => raw.postMessage(message),
+			close: () => raw.close(),
+			onmessage: null
+		};
+		raw.onmessage = event => adapter.onmessage?.({ data: event.data });
+		return adapter;
+	}
+
+	private _post(message: CollaborativeReasoningMessage): void {
+		if (!this._channel) {
+			return;
+		}
+		try {
+			this._channel.postMessage(message);
+		} catch (e) {
+			this.logService.warn(`CollaborativeReasoningService: failed to post message: ${e instanceof Error ? e.message : String(e)}`);
+		}
+	}
+
+	private _appendLog(entry: CollaborativeSessionEntry): void {
+		this._log.push(entry);
+		if (this._log.length > MAX_LOG_ENTRIES) {
+			this._log.shift();
+		}
+	}
+
+	private _onMessage(data: unknown): void {
+		const message = data as CollaborativeReasoningMessage;
+		if (typeof message !== 'object' || message === null || typeof message.peerId !== 'string' || message.peerId === this._peerId) {
+			return;
+		}
+
+		if (message.type === 'hello') {
+			const isNewPeer = !this._knownPeers.has(message.peerId);
+			this._knownPeers.add(message.peerId);
+			// Reply once so the new window learns about us too; the reply is
+			// marked so it is never answered again (prevents a hello storm).
+			if (isNewPeer && !message.reply) {
+				this._post({ type: 'hello', peerId: this._peerId, reply: true });
+			}
+			this._onDidChangeSessionState.fire(this.getState());
+			return;
+		}
+
+		if (message.type === 'phase' && message.phase && typeof message.querySeq === 'number') {
+			this._knownPeers.add(message.peerId);
+			const event: CollaborativePhaseEvent = {
+				peerId: message.peerId,
+				querySeq: message.querySeq,
+				query: message.query,
+				phase: message.phase
+			};
+			this._appendLog({ kind: 'phase', event });
+			this._phasesReceived++;
+			this._onDidReceivePhase.fire(event);
+			return;
+		}
+
+		if (message.type === 'annotation' && typeof message.text === 'string') {
+			this._knownPeers.add(message.peerId);
+			const annotation: CollaborativeAnnotation = {
+				peerId: message.peerId,
+				targetPeerId: message.targetPeerId,
+				targetQuerySeq: message.targetQuerySeq,
+				targetPhaseName: message.targetPhaseName,
+				text: message.text,
+				timestamp: message.timestamp
+			};
+			this._appendLog({ kind: 'annotation', event: annotation });
+			this._annotationsReceived++;
+			this._onDidReceiveAnnotation.fire(annotation);
+		}
+	}
+}

--- a/src/sql/workbench/services/zonecog/browser/zonecog.contribution.ts
+++ b/src/sql/workbench/services/zonecog/browser/zonecog.contribution.ts
@@ -59,6 +59,8 @@ import { IFederatedQueryService } from 'sql/workbench/services/zonecog/common/fe
 import { FederatedQueryService } from 'sql/workbench/services/zonecog/browser/federatedQueryService';
 import { IHypergraphSemanticSearchService } from 'sql/workbench/services/zonecog/common/hypergraphSemanticSearch';
 import { HypergraphSemanticSearchService } from 'sql/workbench/services/zonecog/browser/hypergraphSemanticSearchService';
+import { ICollaborativeReasoningService } from 'sql/workbench/services/zonecog/common/collaborativeReasoning';
+import { CollaborativeReasoningService } from 'sql/workbench/services/zonecog/browser/collaborativeReasoningService';
 
 // Register the Hypergraph store (dependency of ZoneCogService)
 registerSingleton(IHypergraphStore, HypergraphStore, InstantiationType.Eager);
@@ -174,3 +176,8 @@ registerSingleton(IFederatedQueryService, FederatedQueryService, InstantiationTy
 // similarity search over hypergraph nodes, with a deterministic local
 // hashing-trick fallback when no Aphrodite engine is connected)
 registerSingleton(IHypergraphSemanticSearchService, HypergraphSemanticSearchService, InstantiationType.Eager);
+
+// Register the Collaborative Reasoning service (same-machine multi-window
+// live thinking-phase broadcast and shared annotation transcript over a
+// BroadcastChannel; Phase 4.4 "Collaborative reasoning sessions")
+registerSingleton(ICollaborativeReasoningService, CollaborativeReasoningService, InstantiationType.Eager);

--- a/src/sql/workbench/services/zonecog/common/collaborativeReasoning.ts
+++ b/src/sql/workbench/services/zonecog/common/collaborativeReasoning.ts
@@ -1,0 +1,112 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
+import { Event } from 'vs/base/common/event';
+import { ThinkingPhase } from 'sql/workbench/services/zonecog/common/zonecogService';
+
+export const ICollaborativeReasoningService = createDecorator<ICollaborativeReasoningService>('collaborativeReasoningService');
+
+// ---------------------------------------------------------------------------
+// Collaborative reasoning types
+// ---------------------------------------------------------------------------
+
+/** State of the collaborative reasoning session. */
+export interface CollaborativeReasoningState {
+	active: boolean;
+	/** Stable identifier of this participant. */
+	peerId: string;
+	/** Peer ids seen since the session started (excluding self). */
+	knownPeers: string[];
+	phasesSent: number;
+	phasesReceived: number;
+	annotationsSent: number;
+	annotationsReceived: number;
+}
+
+/**
+ * One thinking phase contributed by a participant's live query processing.
+ * `querySeq` scopes phases to a single query for the contributing peer
+ * (bumped whenever that peer's "Initial Engagement" phase - always the
+ * first phase of every query - is observed).
+ */
+export interface CollaborativePhaseEvent {
+	peerId: string;
+	querySeq: number;
+	/** Best-effort query text, when known at broadcast time. */
+	query: string;
+	phase: ThinkingPhase;
+}
+
+/** A short remark one participant attaches to a (possibly own) phase. */
+export interface CollaborativeAnnotation {
+	peerId: string;
+	targetPeerId: string;
+	targetQuerySeq: number;
+	targetPhaseName: string;
+	text: string;
+	/** Epoch milliseconds when the annotation was posted. */
+	timestamp: number;
+}
+
+/** One entry of the unified session transcript, in arrival order. */
+export type CollaborativeSessionEntry =
+	| { kind: 'phase'; event: CollaborativePhaseEvent }
+	| { kind: 'annotation'; event: CollaborativeAnnotation };
+
+// ---------------------------------------------------------------------------
+// Service interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Collaborative reasoning service.
+ *
+ * Closes the same-machine scope of the "Collaborative reasoning sessions"
+ * roadmap item (Phase 4.4): while a session is active, every thinking phase
+ * this window's `IZoneCogService` completes is broadcast live to other
+ * workbench windows over a BroadcastChannel, and every peer's phases are
+ * applied to a local unified transcript alongside this window's own -
+ * turning isolated cognitive processing into a shared, observable reasoning
+ * stream. Participants can also attach short annotations to any phase
+ * (their own or a peer's), enabling lightweight co-reasoning (critique,
+ * confirmation, follow-up prompts) without a shared hypergraph merge. True
+ * multi-user collaboration across machines requires a sync backend and
+ * remains future work.
+ */
+export interface ICollaborativeReasoningService {
+	readonly _serviceBrand: undefined;
+
+	/** Fired for every phase added to the transcript, own or peer. */
+	readonly onDidReceivePhase: Event<CollaborativePhaseEvent>;
+
+	/** Fired for every annotation added to the transcript, own or peer. */
+	readonly onDidReceiveAnnotation: Event<CollaborativeAnnotation>;
+
+	/** Fired when the session starts, stops, or peers are discovered. */
+	readonly onDidChangeSessionState: Event<CollaborativeReasoningState>;
+
+	/**
+	 * Start collaborating: opens the channel, announces this peer, and
+	 * begins mirroring this window's thinking phases to peers. Returns
+	 * false when BroadcastChannel is unavailable in the current
+	 * environment.
+	 */
+	startSession(): boolean;
+
+	/** Stop collaborating and close the channel. */
+	stopSession(): void;
+
+	/** Current session state. */
+	getState(): CollaborativeReasoningState;
+
+	/** Attach a short remark to a phase (own or a peer's) and share it. */
+	postAnnotation(targetPeerId: string, targetQuerySeq: number, targetPhaseName: string, text: string): void;
+
+	/** The unified session transcript (own and peer phases/annotations), oldest first. */
+	getSessionLog(): CollaborativeSessionEntry[];
+
+	/** Clear the recorded transcript (does not affect lifetime counters). */
+	clear(): void;
+}

--- a/src/sql/workbench/services/zonecog/test/browser/collaborativeReasoningService.test.ts
+++ b/src/sql/workbench/services/zonecog/test/browser/collaborativeReasoningService.test.ts
@@ -1,0 +1,261 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { CollaborativeReasoningService, ICollaborativeReasoningChannel } from 'sql/workbench/services/zonecog/browser/collaborativeReasoningService';
+import { CollaborativePhaseEvent, CollaborativeAnnotation } from 'sql/workbench/services/zonecog/common/collaborativeReasoning';
+import { IZoneCogService, ICognitiveMembraneService, ThinkingPhase } from 'sql/workbench/services/zonecog/common/zonecogService';
+import { CognitiveMembraneService } from 'sql/workbench/services/zonecog/browser/cognitiveMembraneService';
+import { ILogService, NullLogService } from 'vs/platform/log/common/log';
+import { Emitter } from 'vs/base/common/event';
+
+/**
+ * In-memory hub standing in for BroadcastChannel: messages posted by one
+ * channel are delivered synchronously to every other channel on the hub.
+ */
+class FakeChannelHub {
+	private readonly _channels: FakeChannel[] = [];
+
+	connect(): FakeChannel {
+		const channel = new FakeChannel(this);
+		this._channels.push(channel);
+		return channel;
+	}
+
+	broadcast(sender: FakeChannel, message: unknown): void {
+		for (const channel of this._channels) {
+			if (channel !== sender && !channel.closed && channel.onmessage) {
+				channel.onmessage({ data: message });
+			}
+		}
+	}
+}
+
+class FakeChannel implements ICollaborativeReasoningChannel {
+	closed = false;
+	onmessage: ((event: { data: unknown }) => void) | null = null;
+	constructor(private readonly hub: FakeChannelHub) { }
+	postMessage(message: unknown): void {
+		this.hub.broadcast(this, message);
+	}
+	close(): void {
+		this.closed = true;
+	}
+}
+
+/** Minimal fake ZoneCogService exposing just what the collaborative service needs. */
+class FakeZoneCogService implements Pick<IZoneCogService, 'onDidCompleteThinkingPhase' | 'getQueryHistory'> {
+	private readonly _onDidCompleteThinkingPhase = new Emitter<ThinkingPhase>();
+	readonly onDidCompleteThinkingPhase = this._onDidCompleteThinkingPhase.event;
+	private readonly _history: Array<{ query: string; timestamp: number }> = [];
+
+	setCurrentQuery(query: string): void {
+		this._history.push({ query, timestamp: Date.now() });
+	}
+
+	getQueryHistory(): Array<{ query: string; timestamp: number }> {
+		return [...this._history];
+	}
+
+	firePhase(phase: ThinkingPhase): void {
+		this._onDidCompleteThinkingPhase.fire(phase);
+	}
+}
+
+/** Service variant whose transport is the in-memory hub. */
+class TestCollaborativeReasoningService extends CollaborativeReasoningService {
+	constructor(
+		private readonly hub: FakeChannelHub | undefined,
+		logService: ILogService,
+		zoneCogService: IZoneCogService,
+		membraneService: ICognitiveMembraneService
+	) {
+		super(logService, zoneCogService, membraneService);
+	}
+	protected override _createChannel(): ICollaborativeReasoningChannel | undefined {
+		return this.hub?.connect();
+	}
+}
+
+function phase(name: string, content = 'content'): ThinkingPhase {
+	return { name, content, durationMs: 1 };
+}
+
+suite('Collaborative Reasoning Service Tests', () => {
+
+	function makeParticipant(hub: FakeChannelHub | undefined): { service: TestCollaborativeReasoningService; zoneCog: FakeZoneCogService } {
+		const logService = new NullLogService();
+		const zoneCog = new FakeZoneCogService();
+		const membrane = new CognitiveMembraneService(logService);
+		const service = new TestCollaborativeReasoningService(hub, logService, zoneCog as unknown as IZoneCogService, membrane);
+		return { service, zoneCog };
+	}
+
+	test('should be inactive until started', () => {
+		const { service } = makeParticipant(new FakeChannelHub());
+		assert.strictEqual(service.getState().active, false);
+		assert.ok(service.startSession());
+		assert.strictEqual(service.getState().active, true);
+		service.stopSession();
+		assert.strictEqual(service.getState().active, false);
+	});
+
+	test('startSession should report failure when the transport is unavailable', () => {
+		const { service } = makeParticipant(undefined);
+		assert.strictEqual(service.startSession(), false);
+	});
+
+	test('peers should discover each other via hello handshake', () => {
+		const hub = new FakeChannelHub();
+		const a = makeParticipant(hub);
+		const b = makeParticipant(hub);
+
+		a.service.startSession();
+		b.service.startSession();
+
+		assert.strictEqual(a.service.getState().knownPeers.length, 1);
+		assert.strictEqual(b.service.getState().knownPeers.length, 1);
+	});
+
+	test('local phases should be recorded and broadcast to peers', () => {
+		const hub = new FakeChannelHub();
+		const a = makeParticipant(hub);
+		const b = makeParticipant(hub);
+		a.service.startSession();
+		b.service.startSession();
+
+		a.zoneCog.setCurrentQuery('what tables exist?');
+		a.zoneCog.firePhase(phase('Initial Engagement', 'hmm...'));
+		a.zoneCog.firePhase(phase('Problem Space Exploration', 'exploring...'));
+
+		assert.strictEqual(a.service.getState().phasesSent, 2);
+		assert.strictEqual(b.service.getState().phasesReceived, 2);
+
+		const bLog = b.service.getSessionLog();
+		assert.strictEqual(bLog.length, 2);
+		assert.strictEqual(bLog[0].kind, 'phase');
+		const first = bLog[0] as { kind: 'phase'; event: CollaborativePhaseEvent };
+		assert.strictEqual(first.event.phase.name, 'Initial Engagement');
+		assert.strictEqual(first.event.query, 'what tables exist?');
+		assert.strictEqual(first.event.querySeq, 1);
+	});
+
+	test('own phases should also appear in the local transcript', () => {
+		const { service, zoneCog } = makeParticipant(new FakeChannelHub());
+		service.startSession();
+
+		zoneCog.firePhase(phase('Initial Engagement'));
+
+		const log = service.getSessionLog();
+		assert.strictEqual(log.length, 1);
+		assert.strictEqual(service.getState().phasesSent, 1);
+	});
+
+	test('querySeq should increment only on Initial Engagement', () => {
+		const { service, zoneCog } = makeParticipant(new FakeChannelHub());
+		service.startSession();
+
+		zoneCog.firePhase(phase('Initial Engagement'));
+		zoneCog.firePhase(phase('Problem Space Exploration'));
+		zoneCog.firePhase(phase('Initial Engagement'));
+
+		const log = service.getSessionLog().map(e => (e as { kind: 'phase'; event: CollaborativePhaseEvent }).event.querySeq);
+		assert.deepStrictEqual(log, [1, 1, 2]);
+	});
+
+	test('phases fired before the session starts should not be recorded', () => {
+		const { service, zoneCog } = makeParticipant(new FakeChannelHub());
+		zoneCog.firePhase(phase('Initial Engagement'));
+		assert.strictEqual(service.getSessionLog().length, 0);
+
+		service.startSession();
+		zoneCog.firePhase(phase('Problem Space Exploration'));
+		assert.strictEqual(service.getSessionLog().length, 1);
+	});
+
+	test('annotations should be shared and appear in both transcripts', () => {
+		const hub = new FakeChannelHub();
+		const a = makeParticipant(hub);
+		const b = makeParticipant(hub);
+		a.service.startSession();
+		b.service.startSession();
+
+		a.service.postAnnotation('peer-x', 3, 'Pattern Recognition and Analysis', '  nice catch!  ');
+
+		assert.strictEqual(a.service.getState().annotationsSent, 1);
+		assert.strictEqual(b.service.getState().annotationsReceived, 1);
+
+		const received: CollaborativeAnnotation[] = [];
+		b.service.onDidReceiveAnnotation(a => received.push(a));
+		a.service.postAnnotation('peer-x', 3, 'Pattern Recognition and Analysis', 'second note');
+		assert.strictEqual(received.length, 1);
+		assert.strictEqual(received[0].text, 'second note');
+
+		const aLog = a.service.getSessionLog();
+		const firstAnnotation = aLog[0] as { kind: 'annotation'; event: CollaborativeAnnotation };
+		assert.strictEqual(firstAnnotation.event.text, 'nice catch!');
+	});
+
+	test('blank annotations should be ignored', () => {
+		const { service } = makeParticipant(new FakeChannelHub());
+		service.startSession();
+		service.postAnnotation('peer-x', 1, 'Initial Engagement', '   ');
+		assert.strictEqual(service.getSessionLog().length, 0);
+		assert.strictEqual(service.getState().annotationsSent, 0);
+	});
+
+	test('should fire onDidReceivePhase for both own and peer phases', () => {
+		const hub = new FakeChannelHub();
+		const a = makeParticipant(hub);
+		const b = makeParticipant(hub);
+		a.service.startSession();
+		b.service.startSession();
+
+		const received: CollaborativePhaseEvent[] = [];
+		b.service.onDidReceivePhase(e => received.push(e));
+
+		a.zoneCog.firePhase(phase('Initial Engagement'));
+		assert.strictEqual(received.length, 1);
+		assert.strictEqual(received[0].peerId, a.service.getState().peerId);
+	});
+
+	test('local phases after stopSession should not propagate', () => {
+		const hub = new FakeChannelHub();
+		const a = makeParticipant(hub);
+		const b = makeParticipant(hub);
+		a.service.startSession();
+		b.service.startSession();
+
+		a.service.stopSession();
+		a.zoneCog.firePhase(phase('Initial Engagement'));
+
+		assert.strictEqual(b.service.getState().phasesReceived, 0);
+	});
+
+	test('clear should empty the transcript without touching lifetime counters', () => {
+		const { service, zoneCog } = makeParticipant(new FakeChannelHub());
+		service.startSession();
+		zoneCog.firePhase(phase('Initial Engagement'));
+
+		service.clear();
+		assert.strictEqual(service.getSessionLog().length, 0);
+		assert.strictEqual(service.getState().phasesSent, 1);
+	});
+
+	test('three peers should all receive a broadcast phase', () => {
+		const hub = new FakeChannelHub();
+		const a = makeParticipant(hub);
+		const b = makeParticipant(hub);
+		const c = makeParticipant(hub);
+		a.service.startSession();
+		b.service.startSession();
+		c.service.startSession();
+
+		b.zoneCog.firePhase(phase('Initial Engagement'));
+
+		assert.strictEqual(a.service.getSessionLog().length, 1);
+		assert.strictEqual(c.service.getSessionLog().length, 1);
+	});
+});


### PR DESCRIPTION
## Description

Proceeding with the next step on the ZoneCog roadmap (`docs/ZONECOG_ROADMAP.md`) surfaced a real build-breaking bug: `src/sql/workbench/contrib/zonecog/browser/zonecogActions.contribution.ts` had unbalanced braces (net +8), left over from three independent PRs (DTESN sensorimotor binding, federated hypergraph query, hypergraph semantic search) that each inserted a class at the exact same insertion point (right after `ZoneCogToggleSharedCognitionAction`). Each PR's diff was individually clean, but the sequential merges spliced their class bodies together instead of concatenating them, dropping several constructor/`run()` boundaries and interleaving unrelated method bodies.

This PR:
1. **Repairs the corruption** by reconstructing all six affected action classes (`ZoneCogToggleFederatedQueryAction`, `ZoneCogFederatedQueryAction`, `ZoneCogIndexSemanticSearchAction`, `ZoneCogSemanticSearchAction`, `ZoneCogToggleSensorimotorBindingAction`, `ZoneCogSensorimotorStatusAction`) from each source commit's original, pre-merge diff. Verified brace depth is now 0 (was +8) and every declared action class has exactly one matching `registerAction2` call (57/57).
2. **Closes the "Collaborative reasoning sessions" roadmap item (Phase 4.4)** with a new `ICollaborativeReasoningService`/`CollaborativeReasoningService`: broadcasts this window's live `onDidCompleteThinkingPhase` stream to other same-machine workbench windows over a BroadcastChannel (same transport pattern as `ISharedCognitionService`), merging every participant's phases into one unified transcript. Participants can attach short annotations to any phase (own or a peer's) for lightweight co-reasoning. True multi-user collaboration across machines still requires a sync backend and remains future work, matching the phrasing already used for the sibling "Shared hypergraph state" item.

## Code Changes Checklist

- [x] New or updated **unit tests** added (`collaborativeReasoningService.test.ts`: session lifecycle, peer discovery, phase broadcast + query-boundary tracking, annotations, multi-peer convergence)
- [ ] All existing tests pass (`npm run test`) — not run: this environment has no installed dependencies (`node_modules` is empty), so the real project `tsc`/mocha harness could not be exercised. Verified instead via brace-balance checks and standalone `tsc --noEmit` parses (no syntax errors; the only diagnostics were module-resolution/isolation artifacts also reproduced by the pre-existing, already-merged `sharedCognitionService.ts` when checked the same way).
- [x] Code follows [contributing guidelines](https://github.com/microsoft/azuredatastudio/blob/main/CONTRIBUTING.md) (mirrors the existing `ISharedCognitionService`/`IFederatedQueryService` BroadcastChannel service pattern)
- [x] No UI regressions introduced (new Command Palette actions only; existing actions' behavior restored to their pre-corruption form)
- [ ] Logging/telemetry updated if applicable — n/a
- [x] Cross-platform support checked (Windows, macOS, Linux if relevant) — no platform-specific code

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/azuredatastudio/blob/main/.github/REVIEW_GUIDELINES.md)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DUQ2ys4XPr2MBRHhQyHekA)_