### PR TITLE
feat(zonecog): standalone Python bridge CLI and Docker container (Phase 5.2)

### DIFF
--- a/azure_integration/Dockerfile
+++ b/azure_integration/Dockerfile
@@ -1,0 +1,27 @@
+# Standalone container for the ZoneCog Python cognitive bridge (Phase 5.2).
+#
+# Build from the repository root so this can COPY the azure_integration
+# package without an ADS/Node.js toolchain in the image:
+#   docker build -f azure_integration/Dockerfile -t zonecog-bridge .
+# Run:
+#   docker run -p 7807:7807 zonecog-bridge
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY azure_integration/requirements.txt azure_integration/requirements.txt
+RUN pip install --no-cache-dir -r azure_integration/requirements.txt
+
+COPY azure_integration azure_integration
+
+ENV HOST=0.0.0.0 \
+    PORT=7807 \
+    ATOMSPACE_MODE=mock
+
+EXPOSE 7807
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD ["python", "-m", "azure_integration.healthcheck"]
+
+ENTRYPOINT ["python", "-m", "azure_integration.cli"]
+CMD ["serve"]

--- a/azure_integration/README.md
+++ b/azure_integration/README.md
@@ -1,0 +1,66 @@
+# ZoneCog Python Bridge — Standalone Cognitive Service
+
+The `azure_integration` package is the Python side of the ZoneCog cognitive
+protocol: it maps SQL schemas/rows into AtomSpace-style Node/Link atoms and
+runs the 4E cognitive pipeline (`data_studio_bridge.py`, `sql_to_atomspace.py`,
+`atomspace_transport.py`). It has no Azure Data Studio or Node.js dependency —
+only `fastapi`, `uvicorn`, and `pydantic` — so it runs standalone (Phase 5.2 of
+`docs/ZONECOG_ROADMAP.md`).
+
+## Running as an HTTP service
+
+```bash
+pip install -r azure_integration/requirements.txt
+python -m azure_integration.cli serve   # or: python -m azure_integration.data_studio_bridge
+```
+
+Reads `HOST` (default `0.0.0.0` in Docker, `127.0.0.1` otherwise), `PORT`
+(default `7807`), `ATOMSPACE_MODE` (`mock` or `http`), and `ATOMSPACE_URL`
+from the environment. Endpoints: `GET /health`, `GET /status`,
+`POST /ingest/schema`, `POST /ingest/table`, `POST /ingest/atoms`,
+`POST /reason`.
+
+## Headless CLI
+
+For scripts and CI that want to drive ingestion/reasoning without standing up
+the HTTP server:
+
+```bash
+python -m azure_integration.cli health
+python -m azure_integration.cli ingest-schema schema.json
+python -m azure_integration.cli ingest-table table.json
+python -m azure_integration.cli ingest-atoms atoms.json
+python -m azure_integration.cli reason reason.json
+python -m azure_integration.cli status
+```
+
+Each subcommand (other than `health`/`status`/`serve`) reads one JSON document
+— from the given file path, or from stdin when omitted or passed `-` — shaped
+like the matching HTTP request body, and prints the JSON result to stdout.
+Non-zero exit and an `error: ...` line on stderr on bad input (missing file,
+invalid JSON, failed validation). Each invocation constructs its own
+`BridgeApp`, so `status`/`ingest-*` counters are per-process, not shared
+across separate CLI calls the way they are across requests to a single running
+`serve` instance.
+
+If installed as a package (`pip install .` from the repo root, using the
+top-level `pyproject.toml`), the same CLI is also available as the
+`zonecog-bridge` console script.
+
+## Docker
+
+```bash
+docker build -f azure_integration/Dockerfile -t zonecog-bridge .
+docker run -p 7807:7807 zonecog-bridge
+```
+
+The image installs only `azure_integration/requirements.txt` and copies the
+`azure_integration` package — no ADS build toolchain — and defaults to
+`serve`. Override the command to run a one-off CLI invocation instead, e.g.
+`docker run --rm -v "$PWD:/data" zonecog-bridge ingest-schema /data/schema.json`.
+
+## Tests
+
+```bash
+python -m pytest azure_integration/tests/ -v --tb=short
+```

--- a/azure_integration/cli.py
+++ b/azure_integration/cli.py
@@ -1,0 +1,151 @@
+"""Headless CLI for the ZoneCog Python cognitive bridge (Phase 5.2).
+
+Drives `BridgeApp` directly — the same request models and business logic
+the FastAPI HTTP layer in `data_studio_bridge.py` uses — so schema/table/atom
+ingestion and reasoning can run from JSON files or stdin in scripts and CI
+without starting the HTTP server or depending on Azure Data Studio.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any, Dict, List, Optional, TextIO
+
+from azure_integration.data_studio_bridge import (
+    BridgeApp,
+    IngestAtomsRequest,
+    IngestSchemaRequest,
+    IngestTableRequest,
+    ReasonRequest,
+)
+
+_INPUT_ERRORS = (OSError, ValueError, KeyError, TypeError, RuntimeError)
+
+
+def _read_json(source: Optional[str]) -> Dict[str, Any]:
+    if source is None or source == "-":
+        return json.load(sys.stdin)
+    with open(source, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _write_json(data: Any, stream: TextIO) -> None:
+    json.dump(data, stream, indent=2, sort_keys=True)
+    stream.write("\n")
+
+
+def cmd_health(app: BridgeApp, args: argparse.Namespace) -> Dict[str, Any]:
+    return app.health()
+
+
+def cmd_status(app: BridgeApp, args: argparse.Namespace) -> Dict[str, Any]:
+    return app.status()
+
+
+def cmd_ingest_schema(app: BridgeApp, args: argparse.Namespace) -> Dict[str, Any]:
+    payload = _read_json(args.input)
+    return app.ingest_schema(IngestSchemaRequest(**payload))
+
+
+def cmd_ingest_table(app: BridgeApp, args: argparse.Namespace) -> Dict[str, Any]:
+    payload = _read_json(args.input)
+    return app.ingest_table(IngestTableRequest(**payload))
+
+
+def cmd_ingest_atoms(app: BridgeApp, args: argparse.Namespace) -> Dict[str, Any]:
+    payload = _read_json(args.input)
+    return app.ingest_atoms(IngestAtomsRequest(**payload))
+
+
+def cmd_reason(app: BridgeApp, args: argparse.Namespace) -> Dict[str, Any]:
+    payload = _read_json(args.input)
+    return app.reason(ReasonRequest(**payload))
+
+
+def _add_input_arg(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "input",
+        nargs="?",
+        default=None,
+        help="path to a JSON document, or '-'/omitted to read from stdin",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="zonecog-bridge",
+        description=(
+            "Headless CLI for the ZoneCog cognitive bridge: schema/table/atom "
+            "ingestion and reasoning against the AtomSpace adapter, without "
+            "requiring a running HTTP server or Azure Data Studio."
+        ),
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_health = sub.add_parser("health", help="report bridge liveness")
+    p_health.set_defaults(func=cmd_health)
+
+    p_status = sub.add_parser("status", help="report processed batch count and last request id")
+    p_status.set_defaults(func=cmd_status)
+
+    p_schema = sub.add_parser(
+        "ingest-schema", help="ingest a {tables, foreign_keys} JSON document"
+    )
+    _add_input_arg(p_schema)
+    p_schema.set_defaults(func=cmd_ingest_schema)
+
+    p_table = sub.add_parser(
+        "ingest-table", help="ingest a {schema, table, primary_key, rows} JSON document"
+    )
+    _add_input_arg(p_table)
+    p_table.set_defaults(func=cmd_ingest_table)
+
+    p_atoms = sub.add_parser(
+        "ingest-atoms", help="ingest a raw {atoms: {nodes, links}} JSON document"
+    )
+    _add_input_arg(p_atoms)
+    p_atoms.set_defaults(func=cmd_ingest_atoms)
+
+    p_reason = sub.add_parser(
+        "reason",
+        help="run the 4E cognitive pipeline and AtomSpace reasoning over a {atoms, mode, context} JSON document",
+    )
+    _add_input_arg(p_reason)
+    p_reason.set_defaults(func=cmd_reason)
+
+    p_serve = sub.add_parser(
+        "serve", help="start the FastAPI HTTP bridge server (reads HOST/PORT env vars)"
+    )
+    p_serve.set_defaults(func=None)
+
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    # Resolve sys.stdout/sys.stderr at call time (not as default-argument
+    # values) so test harnesses that monkeypatch/capture them still work.
+    stdout = sys.stdout
+    stderr = sys.stderr
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "serve":
+        from azure_integration.data_studio_bridge import main as serve_main
+
+        serve_main()
+        return 0
+
+    app = BridgeApp()
+    try:
+        result = args.func(app, args)
+    except _INPUT_ERRORS as exc:
+        print(f"error: {exc}", file=stderr)
+        return 1
+
+    _write_json(result, stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/azure_integration/healthcheck.py
+++ b/azure_integration/healthcheck.py
@@ -1,0 +1,25 @@
+"""Docker HEALTHCHECK probe for the standalone ZoneCog bridge container.
+
+Standard library only, so the container image needs no extra dependency
+just to answer "is the bridge up" from `docker ps` / orchestrator probes.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import urllib.error
+import urllib.request
+
+
+def main() -> int:
+    port = os.environ.get("PORT", "7807")
+    url = f"http://127.0.0.1:{port}/health"
+    try:
+        with urllib.request.urlopen(url, timeout=2) as response:
+            return 0 if response.status == 200 else 1
+    except (urllib.error.URLError, OSError):
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/azure_integration/tests/test_cli.py
+++ b/azure_integration/tests/test_cli.py
@@ -1,0 +1,185 @@
+"""Tests for the headless ZoneCog bridge CLI (azure_integration.cli).
+
+Covers each subcommand end-to-end through `main()` (file input, stdin input,
+and error paths) plus the underlying `cmd_*` handlers against a real
+`BridgeApp` instance (no HTTP layer, no mocks).
+"""
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from azure_integration import cli
+from azure_integration.data_studio_bridge import BridgeApp
+
+
+SCHEMA_DOC: Dict[str, Any] = {
+    "tables": [{"schema": "dbo", "table": "Users", "columns": [{"name": "Id"}, {"name": "Name"}]}],
+    "foreign_keys": [],
+}
+
+TABLE_DOC: Dict[str, Any] = {
+    "schema": "dbo",
+    "table": "Users",
+    "primary_key": "Id",
+    "rows": [{"Id": 1, "Name": "Ada"}],
+}
+
+ATOMS_DOC: Dict[str, Any] = {
+    "atoms": {
+        "nodes": [{"type": "Node", "node_type": "TableNode", "name": "dbo.Users", "uuid": "abc"}],
+        "links": [],
+    }
+}
+
+REASON_DOC: Dict[str, Any] = {"atoms": ATOMS_DOC["atoms"], "mode": "default", "context": {}}
+
+
+def _write(tmp_path: Path, name: str, doc: Dict[str, Any]) -> str:
+    p = tmp_path / name
+    p.write_text(json.dumps(doc), encoding="utf-8")
+    return str(p)
+
+
+class TestCommandHandlers:
+    def test_health_reports_ok(self) -> None:
+        app = BridgeApp()
+        result = cli.cmd_health(app, argparse_namespace())
+        assert result["status"] == "ok"
+        assert "time" in result
+
+    def test_status_starts_at_zero(self) -> None:
+        app = BridgeApp()
+        result = cli.cmd_status(app, argparse_namespace())
+        assert result == {"status": "ok", "processed_batches": 0, "last_request_id": None}
+
+    def test_ingest_schema_from_file(self, tmp_path: Path) -> None:
+        app = BridgeApp()
+        path = _write(tmp_path, "schema.json", SCHEMA_DOC)
+        result = cli.cmd_ingest_schema(app, argparse_namespace(input=path))
+        assert result["upsert"]["nodes"] == 3  # TableNode + 2 ColumnNodes
+        assert app.processed_batches == 1
+
+    def test_ingest_table_from_file(self, tmp_path: Path) -> None:
+        app = BridgeApp()
+        path = _write(tmp_path, "table.json", TABLE_DOC)
+        result = cli.cmd_ingest_table(app, argparse_namespace(input=path))
+        assert result["upsert"]["status"] == "ok"
+        assert app.processed_batches == 1
+
+    def test_ingest_atoms_from_file(self, tmp_path: Path) -> None:
+        app = BridgeApp()
+        path = _write(tmp_path, "atoms.json", ATOMS_DOC)
+        result = cli.cmd_ingest_atoms(app, argparse_namespace(input=path))
+        assert result["upsert"]["nodes"] == 1
+        assert result["upsert"]["links"] == 0
+
+    def test_reason_from_file(self, tmp_path: Path) -> None:
+        app = BridgeApp()
+        path = _write(tmp_path, "reason.json", REASON_DOC)
+        result = cli.cmd_reason(app, argparse_namespace(input=path))
+        assert result["cognitive"]["mode"] == "default"
+        assert result["adapter"]["status"] == "ok"
+
+
+class TestMainEndToEnd:
+    def test_health_via_main(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = cli.main(["health"])
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["status"] == "ok"
+
+    def test_ingest_schema_via_main_with_file(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        path = _write(tmp_path, "schema.json", SCHEMA_DOC)
+        rc = cli.main(["ingest-schema", path])
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["upsert"]["nodes"] == 3
+
+    def test_ingest_atoms_via_main_with_stdin(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(ATOMS_DOC)))
+        rc = cli.main(["ingest-atoms"])
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["upsert"]["nodes"] == 1
+
+    def test_ingest_atoms_via_main_with_explicit_dash(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(ATOMS_DOC)))
+        rc = cli.main(["ingest-atoms", "-"])
+        assert rc == 0
+
+    def test_status_reflects_prior_processed_batches_within_one_process(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Each `main()` call constructs a fresh BridgeApp, so status is
+        # necessarily per-invocation for the CLI (unlike the long-lived HTTP
+        # server); assert that invariant rather than cross-call state.
+        rc = cli.main(["status"])
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["processed_batches"] == 0
+
+    def test_missing_file_reports_error_and_nonzero_exit(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = cli.main(["ingest-schema", "/nonexistent/path/schema.json"])
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "error:" in captured.err
+
+    def test_invalid_json_reports_error_and_nonzero_exit(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        path = tmp_path / "bad.json"
+        path.write_text("{not valid json", encoding="utf-8")
+        rc = cli.main(["ingest-schema", str(path)])
+        assert rc == 1
+        assert "error:" in capsys.readouterr().err
+
+    def test_missing_required_field_reports_error_and_nonzero_exit(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # ingest-table requires "table" and "primary_key"; this doc has neither.
+        path = _write(tmp_path, "incomplete_table.json", {"schema": "dbo", "rows": []})
+        rc = cli.main(["ingest-table", path])
+        assert rc == 1
+        assert "error:" in capsys.readouterr().err
+
+    def test_no_command_exits_nonzero(self) -> None:
+        with pytest.raises(SystemExit):
+            cli.main([])
+
+
+class TestParser:
+    def test_all_subcommands_registered(self) -> None:
+        parser = cli.build_parser()
+        subparsers_action = next(
+            a for a in parser._subparsers._group_actions if hasattr(a, "choices")  # type: ignore[attr-defined]
+        )
+        assert set(subparsers_action.choices) == {  # type: ignore[attr-defined]
+            "health",
+            "status",
+            "ingest-schema",
+            "ingest-table",
+            "ingest-atoms",
+            "reason",
+            "serve",
+        }
+
+    def test_input_defaults_to_none(self) -> None:
+        parser = cli.build_parser()
+        args = parser.parse_args(["ingest-atoms"])
+        assert args.input is None
+
+
+def argparse_namespace(**kwargs: Any) -> Any:
+    from argparse import Namespace
+
+    return Namespace(**kwargs)

--- a/docs/ZONECOG_ROADMAP.md
+++ b/docs/ZONECOG_ROADMAP.md
@@ -15,7 +15,7 @@
 | 3 | Intelligence Layer | **Complete** (ECH-61) | AI/LLM integration, pattern mining, reasoning, real AtomSpace transport |
 | 4 | Workbench UX | **Complete** | Visual cognitive maps, interactive exploration |
 | 4.5 | Release Infrastructure | **Complete** (ECH-61) | Multi-platform builds, CI/CD, quality gates |
-| 5 | Post-ADS Migration | Planned | VS Code standalone, portable cognitive workbench |
+| 5 | Post-ADS Migration | **In Progress** | VS Code standalone, portable cognitive workbench |
 
 ---
 
@@ -245,7 +245,7 @@
 
 ---
 
-## Phase 5: Post-ADS Migration (Planned)
+## Phase 5: Post-ADS Migration (In Progress)
 
 **Goal**: Ensure ZoneCog survives ADS retirement as a standalone tool.
 
@@ -256,10 +256,10 @@
 - [ ] Maintain backward compatibility with ADS installations
 
 ### 5.2 Portable Cognitive Engine
-- [ ] Standalone Python cognitive service (no ADS dependency)
-- [ ] Docker container for cognitive services
-- [ ] API-first design for integration with other tools
-- [ ] CLI interface for headless cognitive processing
+- [x] Standalone Python cognitive service (no ADS dependency) — `azure_integration/` depends only on `fastapi`/`uvicorn`/`pydantic`, no ADS or Node.js runtime dependency
+- [x] API-first design for integration with other tools — `data_studio_bridge.py` FastAPI HTTP surface (`/health`, `/status`, `/ingest/schema`, `/ingest/table`, `/ingest/atoms`, `/reason`)
+- [x] CLI interface for headless cognitive processing — `azure_integration/cli.py` (`zonecog-bridge` console script via the top-level `pyproject.toml`): `health`/`status`/`ingest-schema`/`ingest-table`/`ingest-atoms`/`reason`/`serve`, file or stdin JSON in, JSON out, non-zero exit + `error:` on stderr on bad input
+- [x] Docker container for cognitive services — `azure_integration/Dockerfile` (standalone `python:3.11-slim` image, `HEALTHCHECK` via `azure_integration/healthcheck.py`), documented in `azure_integration/README.md`
 
 ### 5.3 EchoCog Integration
 - [ ] Deep integration with Aphrodite Engine for LLM inference

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "zonecog-bridge"
+version = "0.1.0"
+description = "Standalone ZoneCog cognitive bridge: SQL-to-AtomSpace mapping, FastAPI HTTP service, and headless CLI"
+requires-python = ">=3.9"
+dependencies = [
+    "fastapi>=0.110,<1",
+    "uvicorn[standard]>=0.23,<1",
+    "pydantic>=2.5,<3",
+]
+
+[project.scripts]
+zonecog-bridge = "azure_integration.cli:main"
+
+[tool.setuptools]
+packages = ["azure_integration"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,9 @@ version = "0.1.0"
 description = "Standalone ZoneCog cognitive bridge: SQL-to-AtomSpace mapping, FastAPI HTTP service, and headless CLI"
 requires-python = ">=3.9"
 dependencies = [
-    "fastapi>=0.110,<1",
-    "uvicorn[standard]>=0.23,<1",
-    "pydantic>=2.5,<3",
+	"fastapi>=0.110,<1",
+	"uvicorn[standard]>=0.23,<1",
+	"pydantic>=2.5,<3",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Description

Continues the ZoneCog roadmap (`docs/ZONECOG_ROADMAP.md`) into **Phase 5: Post-ADS Migration**, specifically the "Portable Cognitive Engine" (5.2) checklist. All prior phases (1 through 4.5) are complete and there were no open issues/PRs to pick up, so this closes out the remaining unstarted items in 5.2:

- **Headless CLI** — `azure_integration/cli.py` drives the existing `BridgeApp` (same request models/business logic the FastAPI HTTP layer in `data_studio_bridge.py` uses) directly, with subcommands `health`, `status`, `ingest-schema`, `ingest-table`, `ingest-atoms`, `reason`, and `serve`. Each ingestion/reasoning subcommand reads one JSON document from a file path or stdin (`-`/omitted) and prints the JSON result to stdout; bad input (missing file, invalid JSON, failed validation) exits non-zero with an `error: ...` line on stderr.
- **Docker container** — `azure_integration/Dockerfile` builds a standalone `python:3.11-slim` image (installs only `azure_integration/requirements.txt`, no ADS/Node toolchain) with a `HEALTHCHECK` backed by a new stdlib-only `azure_integration/healthcheck.py` probe.
- **Packaging** — top-level `pyproject.toml` makes the bridge pip-installable and registers the CLI as the `zonecog-bridge` console script.
- **Docs** — new `azure_integration/README.md` documents running the HTTP service, the CLI, and Docker usage; `docs/ZONECOG_ROADMAP.md` Phase 5.2 checkboxes updated with file references, Phase 5 status moved from "Planned" to "In Progress".

The FastAPI bridge already had no ADS dependency, so the "Standalone Python cognitive service" and "API-first design" checklist items were already true and are now just marked complete with citations, consistent with the roadmap's existing style.

## Code Changes Checklist

- [x] New or updated **unit tests** added — `azure_integration/tests/test_cli.py` (parser structure, every subcommand handler against a real `BridgeApp`, `main()` end-to-end via file input/stdin, and error paths: missing file, invalid JSON, failed pydantic validation)
- [x] All existing tests pass — `python -m pytest azure_integration/tests/ -v --tb=short` → 64 passed, 9 skipped (pre-existing `httpx`-gated FastAPI endpoint tests, unrelated to this change)
- [x] Code follows contributing guidelines / `.github/agents/zonecog.agent.md` conventions (no mocks/placeholders; production-grade implementations only)
- [x] No UI regressions introduced — Python-only change, no TypeScript/workbench files touched
- [ ] Logging/telemetry updated if applicable — n/a (CLI is a thin adapter over existing `BridgeApp` methods, which already own their own status tracking)
- [x] Cross-platform support checked — pure Python + `argparse`/`urllib` stdlib, no OS-specific code; the existing CI job (`.github/workflows/basic.yml`) already runs `python -m pytest azure_integration/tests/`, which now includes `test_cli.py`

## Test plan

- [x] `python -m pytest azure_integration/tests/ -v --tb=short`
- [x] `python -m azure_integration.cli health` / manual smoke of each subcommand
- [x] `python -m azure_integration.healthcheck` (verified correct non-zero exit with no server running)
- [ ] `docker build -f azure_integration/Dockerfile -t zonecog-bridge .` — not runnable in this sandbox (no Docker daemon available); Dockerfile reviewed manually for correctness

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/azuredatastudio/blob/main/.github/REVIEW_GUIDELINES.md)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CCrg1EzjZJgizfyRvdDcaV)_