### PR TITLE
feat(zonecog): add Autognosis self-monitoring service (Phase 5.3)

### DIFF
--- a/docs/ZONECOG_ROADMAP.md
+++ b/docs/ZONECOG_ROADMAP.md
@@ -2,7 +2,7 @@
 
 **Ticket**: ECH-4  
 **Status**: Active  
-**Last Updated**: 2026-07-27
+**Last Updated**: 2026-07-28
 
 ## Phase Overview
 
@@ -265,7 +265,7 @@
 - [ ] Deep integration with Aphrodite Engine for LLM inference
 - [ ] OpenCog Hyperon AtomSpace backend
 - [ ] FlareCog distributed cognitive processing
-- [ ] Autognosis self-monitoring capabilities
+- [x] Autognosis self-monitoring capabilities — `IAutognosisService`/`AutognosisService` (meta-cognitive layer that synthesizes membrane triad health, embodiment proprioception, and cognitive analytics into a first-person `SelfAssessment` with a verdict, self-confidence score, and detected anomalies; self-wires to `IZoneCogService.onDidProcessQuery` so every processed query triggers a fresh assessment, persisted as `SelfAssessment` hypergraph nodes; `Zone-Cog: Perform Self-Assessment` and `Zone-Cog: Show Self-Assessment History` Command Palette actions)
 
 ---
 

--- a/scripts/test-zonecog-smoke.sh
+++ b/scripts/test-zonecog-smoke.sh
@@ -25,6 +25,7 @@ ACTUAL_SERVICES=$(grep -c "registerSingleton" src/sql/workbench/services/zonecog
 if [ "$ACTUAL_SERVICES" -ge "$EXPECTED_SERVICES" ]; then
 	echo "   ✓ Found $ACTUAL_SERVICES registered services (expected >= $EXPECTED_SERVICES)"
 else
+	# allow-any-unicode-next-line
 	echo "   ✗ Found $ACTUAL_SERVICES registered services (expected >= $EXPECTED_SERVICES)"
 	exit 1
 fi
@@ -49,6 +50,7 @@ for SERVICE in "${CORE_SERVICES[@]}"; do
 	if [ -f "src/sql/workbench/services/zonecog/browser/$SERVICE" ]; then
 		echo "   ✓ $SERVICE"
 	else
+		# allow-any-unicode-next-line
 		echo "   ✗ $SERVICE (MISSING)"
 		MISSING=$((MISSING + 1))
 	fi
@@ -77,6 +79,7 @@ for IFACE in "${INTERFACE_FILES[@]}"; do
 	if [ -f "src/sql/workbench/services/zonecog/common/$IFACE" ]; then
 		echo "   ✓ $IFACE"
 	else
+		# allow-any-unicode-next-line
 		echo "   ✗ $IFACE (MISSING)"
 		exit 1
 	fi
@@ -90,6 +93,7 @@ if [ -f "$ACTIONS_FILE" ]; then
 	ACTION_COUNT=$(grep -c "registerAction2" "$ACTIONS_FILE" || echo "0")
 	echo "   ✓ $ACTION_COUNT actions registered"
 else
+	# allow-any-unicode-next-line
 	echo "   ✗ Actions contribution file missing"
 	exit 1
 fi
@@ -100,6 +104,7 @@ echo "5. Verifying product.json Zone-Cog configuration..."
 if grep -q "zoneCogConfig" product.json; then
 	echo "   ✓ zoneCogConfig present in product.json"
 else
+	# allow-any-unicode-next-line
 	echo "   ✗ zoneCogConfig missing from product.json"
 	exit 1
 fi
@@ -110,6 +115,7 @@ echo "6. Verifying release infrastructure..."
 if [ -f ".github/workflows/release.yml" ]; then
 	echo "   ✓ release.yml workflow present"
 else
+	# allow-any-unicode-next-line
 	echo "   ✗ release.yml workflow missing"
 	exit 1
 fi
@@ -117,6 +123,7 @@ fi
 if [ -f "build/checksums/generate-checksums.js" ]; then
 	echo "   ✓ Checksum generator present"
 else
+	# allow-any-unicode-next-line
 	echo "   ✗ Checksum generator missing"
 	exit 1
 fi
@@ -124,6 +131,7 @@ fi
 if [ -f "docs/RELEASE_GUIDE.md" ]; then
 	echo "   ✓ Release guide present"
 else
+	# allow-any-unicode-next-line
 	echo "   ✗ Release guide missing"
 	exit 1
 fi
@@ -139,6 +147,7 @@ for TEST in "${TEST_FILES[@]}"; do
 	if [ -f "src/sql/workbench/services/zonecog/test/browser/$TEST" ]; then
 		echo "   ✓ $TEST"
 	else
+		# allow-any-unicode-next-line
 		echo "   ✗ $TEST (MISSING)"
 		exit 1
 	fi

--- a/src/sql/workbench/contrib/zonecog/browser/zonecogActions.contribution.ts
+++ b/src/sql/workbench/contrib/zonecog/browser/zonecogActions.contribution.ts
@@ -41,6 +41,7 @@ import { IFederatedQueryService } from 'sql/workbench/services/zonecog/common/fe
 import { IHypergraphSemanticSearchService } from 'sql/workbench/services/zonecog/common/hypergraphSemanticSearch';
 import { ICollaborativeReasoningService, CollaborativePhaseEvent } from 'sql/workbench/services/zonecog/common/collaborativeReasoning';
 import { IAtomSpaceTransportService } from 'sql/workbench/services/zonecog/common/atomSpaceTransport';
+import { IAutognosisService } from 'sql/workbench/services/zonecog/common/autognosis';
 
 const ZONECOG_CATEGORY = { value: localize('zonecog.category', 'Zone-Cog'), original: 'Zone-Cog' };
 
@@ -2900,6 +2901,78 @@ class ZoneCogAtomSpaceStatusAction extends Action2 {
 registerAction2(ZoneCogConfigureAtomSpaceTransportAction);
 registerAction2(ZoneCogSyncAtomSpaceAction);
 registerAction2(ZoneCogAtomSpaceStatusAction);
+
+/**
+ * Action to perform a self-assessment (Phase 5.3 autognosis) and show the
+ * resulting first-person narrative and verdict.
+ */
+class ZoneCogSelfAssessAction extends Action2 {
+
+	static ID = 'zonecog.autognosis.selfAssess';
+	constructor() {
+		super({
+			id: ZoneCogSelfAssessAction.ID,
+			title: { value: localize('zonecog.selfAssess', 'Perform Self-Assessment'), original: 'Perform Self-Assessment' },
+			category: ZONECOG_CATEGORY,
+			icon: Codicon.eye,
+			f1: true,
+			menu: { id: MenuId.CommandPalette },
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const autognosisService = accessor.get(IAutognosisService);
+		const notificationService = accessor.get(INotificationService);
+
+		const assessment = autognosisService.performSelfAssessment();
+		const verdictNotifier = assessment.verdict === 'critical'
+			? notificationService.error.bind(notificationService)
+			: assessment.verdict === 'degraded'
+				? notificationService.warn.bind(notificationService)
+				: notificationService.info.bind(notificationService);
+
+		verdictNotifier(localize('zonecog.selfAssessResult',
+			'[{0}] (confidence {1}%) {2}',
+			assessment.verdict, Math.round(assessment.selfConfidence * 100), assessment.narrative));
+	}
+}
+
+/**
+ * Action to show the retained self-assessment history and confidence trend.
+ */
+class ZoneCogSelfAssessHistoryAction extends Action2 {
+
+	static ID = 'zonecog.autognosis.showHistory';
+	constructor() {
+		super({
+			id: ZoneCogSelfAssessHistoryAction.ID,
+			title: { value: localize('zonecog.selfAssessHistory', 'Show Self-Assessment History'), original: 'Show Self-Assessment History' },
+			category: ZONECOG_CATEGORY,
+			icon: Codicon.history,
+			f1: true,
+			menu: { id: MenuId.CommandPalette },
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const autognosisService = accessor.get(IAutognosisService);
+		const notificationService = accessor.get(INotificationService);
+
+		const history = autognosisService.getAssessmentHistory(10);
+		if (history.length === 0) {
+			notificationService.info(localize('zonecog.selfAssessHistoryEmpty', 'No self-assessments have been performed yet.'));
+			return;
+		}
+
+		const trend = autognosisService.getTrend();
+		const lines = history.map(a => `[${new Date(a.timestamp).toLocaleTimeString()}] ${a.verdict} (confidence ${Math.round(a.selfConfidence * 100)}%)`);
+		notificationService.info(localize('zonecog.selfAssessHistoryResult',
+			'Self-assessment trend: {0}\n{1}', trend, lines.join('\n')));
+	}
+}
+
+registerAction2(ZoneCogSelfAssessAction);
+registerAction2(ZoneCogSelfAssessHistoryAction);
 
 // Register the cognitive loop status bar contribution so the loop state is
 // always visible in the workbench status bar.

--- a/src/sql/workbench/services/zonecog/README.md
+++ b/src/sql/workbench/services/zonecog/README.md
@@ -172,6 +172,49 @@ reachability changes fire `onDidChangeConnectionStatus`.
 | `zonecog.atomSpaceTransport.syncNow` | Push the current hypergraph to the bridge |
 | `zonecog.atomSpaceTransport.showStatus` | Show bridge reachability and last sync outcome |
 
+### Autognosis (Phase 5.3)
+
+`IAutognosisService` / `AutognosisService` closes the "Autognosis
+self-monitoring capabilities" roadmap gap: a meta-cognitive layer that
+reflects on the cognitive system's *own* state rather than measuring
+anything directly. It synthesizes signals already reported by the
+Cognitive Membrane (triad health), Embodied Cognition (proprioceptive
+load/focus/health), and Cognitive Analytics (LLM fallback ratio, DTESN
+convergence) services into a single first-person `SelfAssessment`:
+
+- **Verdict** — `nominal` / `degraded` / `critical`, driven by unhealthy
+  membrane/embodiment observations and detected anomalies
+- **Self-confidence** — a `[0, 1]` score that discounts for each unhealthy
+  subsystem and each anomaly
+- **Narrative** — a human-readable, first-person reflective summary
+- **Anomalies** — e.g. sustained high cognitive load, a high LLM fallback
+  ratio, or non-converging DTESN training
+
+The service self-wires to `IZoneCogService.onDidProcessQuery`, so every
+completed query triggers a fresh self-assessment automatically; each
+assessment is persisted as a `SelfAssessment` hypergraph node for
+longitudinal introspection, and the bounded history exposes a
+`getTrend()` read (`improving` / `stable` / `degrading`) over recent
+self-confidence scores.
+
+```typescript
+const assessment = autognosisService.performSelfAssessment();
+console.log(assessment.verdict, assessment.selfConfidence, assessment.narrative);
+
+autognosisService.onDidCompleteSelfAssessment(a => {
+  if (a.verdict !== 'nominal') {
+    console.warn('Self-assessment:', a.narrative);
+  }
+});
+```
+
+#### Command Palette Actions
+
+| Command ID | Description |
+|---|---|
+| `zonecog.autognosis.selfAssess` | Perform a self-assessment now and show the verdict and narrative |
+| `zonecog.autognosis.showHistory` | Show recent self-assessments and the confidence trend |
+
 ### Thinking Protocol Phases
 
 The full Zone-Cog cognitive sequence (depth-adaptive):

--- a/src/sql/workbench/services/zonecog/browser/autognosisService.ts
+++ b/src/sql/workbench/services/zonecog/browser/autognosisService.ts
@@ -1,0 +1,244 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import {
+	IAutognosisService,
+	SelfAssessment,
+	SubsystemObservation,
+	AutognosisVerdict,
+	AutognosisTrend
+} from 'sql/workbench/services/zonecog/common/autognosis';
+import { IZoneCogService, IHypergraphStore, ICognitiveMembraneService } from 'sql/workbench/services/zonecog/common/zonecogService';
+import { IEmbodiedCognitionService } from 'sql/workbench/services/zonecog/common/embodiedCognition';
+import { ICognitiveAnalyticsService } from 'sql/workbench/services/zonecog/common/cognitiveAnalytics';
+import { Disposable } from 'vs/base/common/lifecycle';
+import { Emitter, Event } from 'vs/base/common/event';
+import { ILogService } from 'vs/platform/log/common/log';
+
+/** Maximum number of self-assessments retained in the bounded history. */
+const MAX_HISTORY = 200;
+
+/** Node type used for persisted self-assessments in the hypergraph store. */
+const ASSESSMENT_NODE_TYPE = 'SelfAssessment';
+
+/** Salience assigned to persisted assessment nodes per verdict. */
+const VERDICT_SALIENCE: Record<AutognosisVerdict, number> = {
+	nominal: 0.3,
+	degraded: 0.6,
+	critical: 0.9
+};
+
+/** Cognitive load above this threshold is flagged as an anomaly. */
+const HIGH_LOAD_THRESHOLD = 0.85;
+
+/** Fraction of LLM requests served by fallback above which is flagged as an anomaly. */
+const HIGH_FALLBACK_RATIO_THRESHOLD = 0.5;
+
+/** Minimum LLM request count before the fallback-ratio anomaly check applies. */
+const MIN_REQUESTS_FOR_FALLBACK_CHECK = 5;
+
+/** Number of most-recent assessments considered when computing the trend. */
+const TREND_WINDOW = 5;
+
+let assessmentIdCounter = 0;
+
+function assessmentId(): string {
+	return `self-assessment-${Date.now()}-${++assessmentIdCounter}`;
+}
+
+/**
+ * Implementation of the Autognosis service.
+ *
+ * Synthesizes a first-person self-assessment from the membrane, embodiment,
+ * and analytics subsystems' own reported state, rather than re-measuring
+ * anything directly. Self-wires to `IZoneCogService.onDidProcessQuery` so
+ * every completed query triggers a fresh assessment.
+ */
+export class AutognosisService extends Disposable implements IAutognosisService {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _history: SelfAssessment[] = [];
+
+	private readonly _onDidCompleteSelfAssessment = this._register(new Emitter<SelfAssessment>());
+	readonly onDidCompleteSelfAssessment: Event<SelfAssessment> = this._onDidCompleteSelfAssessment.event;
+
+	constructor(
+		@ILogService private readonly logService: ILogService,
+		@IHypergraphStore private readonly hypergraphStore: IHypergraphStore,
+		@ICognitiveMembraneService private readonly membraneService: ICognitiveMembraneService,
+		@IEmbodiedCognitionService private readonly embodiedService: IEmbodiedCognitionService,
+		@ICognitiveAnalyticsService private readonly analyticsService: ICognitiveAnalyticsService,
+		@IZoneCogService zonecogService: IZoneCogService
+	) {
+		super();
+		this._register(zonecogService.onDidProcessQuery(() => this.performSelfAssessment()));
+		this.logService.info('AutognosisService: initialized self-monitoring');
+	}
+
+	// -- Self-assessment ---------------------------------------------------------
+
+	performSelfAssessment(): SelfAssessment {
+		this.membraneService.recordActivity('autonomic');
+
+		const observations = this._collectObservations();
+		const anomalies = this._detectAnomalies();
+		const verdict = this._computeVerdict(observations, anomalies);
+		const selfConfidence = this._computeSelfConfidence(observations, anomalies);
+		const narrative = this._buildNarrative(verdict, observations, anomalies);
+
+		const assessment: SelfAssessment = {
+			id: assessmentId(),
+			timestamp: Date.now(),
+			verdict,
+			selfConfidence,
+			narrative,
+			observations,
+			anomalies
+		};
+
+		this._history.unshift(assessment);
+		while (this._history.length > MAX_HISTORY) {
+			const evicted = this._history.pop();
+			if (evicted) {
+				this.hypergraphStore.removeNode(evicted.id);
+			}
+		}
+
+		this._persistAssessment(assessment);
+		this.logService.info(`AutognosisService: self-assessment ${verdict} (confidence ${selfConfidence.toFixed(2)}, ${anomalies.length} anomal${anomalies.length === 1 ? 'y' : 'ies'})`);
+		this._onDidCompleteSelfAssessment.fire(assessment);
+		return assessment;
+	}
+
+	getLatestAssessment(): SelfAssessment | undefined {
+		return this._history[0];
+	}
+
+	getAssessmentHistory(limit?: number): SelfAssessment[] {
+		return limit !== undefined && limit >= 0 ? this._history.slice(0, limit) : this._history.slice();
+	}
+
+	getTrend(): AutognosisTrend {
+		const window = this._history.slice(0, TREND_WINDOW);
+		if (window.length < 2) {
+			return 'stable';
+		}
+		// window[0] is most recent, window[window.length - 1] is oldest in the window.
+		const delta = window[0].selfConfidence - window[window.length - 1].selfConfidence;
+		if (delta > 0.05) {
+			return 'improving';
+		}
+		if (delta < -0.05) {
+			return 'degrading';
+		}
+		return 'stable';
+	}
+
+	reset(): void {
+		for (const assessment of this._history) {
+			this.hypergraphStore.removeNode(assessment.id);
+		}
+		this._history.length = 0;
+		this.logService.info('AutognosisService: assessment history reset');
+	}
+
+	// -- Internals ------------------------------------------------------------------------
+
+	private _collectObservations(): SubsystemObservation[] {
+		const observations: SubsystemObservation[] = this.membraneService.getAllStatuses().map(status => ({
+			subsystem: status.triad,
+			healthy: status.healthy,
+			detail: `${status.errorCount} error(s), ${status.activeProcesses} activit${status.activeProcesses === 1 ? 'y' : 'ies'} recorded`
+		}));
+
+		const proprioception = this.embodiedService.getProprioceptiveState();
+		observations.push({
+			subsystem: 'embodiment',
+			healthy: proprioception.healthy,
+			detail: `cognitive load ${(proprioception.cognitiveLoad * 100).toFixed(0)}%, focus=${proprioception.attentionalFocus ?? 'none'}`
+		});
+
+		return observations;
+	}
+
+	private _detectAnomalies(): string[] {
+		const anomalies: string[] = [];
+
+		const proprioception = this.embodiedService.getProprioceptiveState();
+		if (proprioception.cognitiveLoad > HIGH_LOAD_THRESHOLD) {
+			anomalies.push(`sustained high cognitive load (${(proprioception.cognitiveLoad * 100).toFixed(0)}%)`);
+		}
+
+		const snapshot = this.analyticsService.getSnapshot();
+
+		const tokens = snapshot.tokenEconomics;
+		if (tokens.requestCount >= MIN_REQUESTS_FOR_FALLBACK_CHECK
+			&& (tokens.fallbackCount / tokens.requestCount) > HIGH_FALLBACK_RATIO_THRESHOLD) {
+			anomalies.push('most LLM requests are being served by the built-in fallback provider');
+		}
+
+		const dtesn = snapshot.dtesnConvergence;
+		if (dtesn.trainingRuns > 1 && !dtesn.converging) {
+			anomalies.push('DTESN readout training is not converging');
+		}
+
+		return anomalies;
+	}
+
+	private _computeVerdict(observations: SubsystemObservation[], anomalies: string[]): AutognosisVerdict {
+		if (observations.some(o => !o.healthy)) {
+			return 'critical';
+		}
+		if (anomalies.length > 0) {
+			return 'degraded';
+		}
+		return 'nominal';
+	}
+
+	private _computeSelfConfidence(observations: SubsystemObservation[], anomalies: string[]): number {
+		const unhealthyCount = observations.filter(o => !o.healthy).length;
+		const confidence = 1 - (unhealthyCount * 0.2) - (anomalies.length * 0.1);
+		return Math.max(0, Math.min(1, confidence));
+	}
+
+	private _buildNarrative(verdict: AutognosisVerdict, observations: SubsystemObservation[], anomalies: string[]): string {
+		const unhealthy = observations.filter(o => !o.healthy).map(o => o.subsystem);
+
+		if (verdict === 'nominal') {
+			return 'I am functioning normally: all monitored subsystems report healthy and no anomalies were detected.';
+		}
+
+		const parts: string[] = [];
+		if (unhealthy.length > 0) {
+			parts.push(`the following subsystem(s) report unhealthy: ${unhealthy.join(', ')}`);
+		}
+		if (anomalies.length > 0) {
+			parts.push(`I have detected ${anomalies.length} anomal${anomalies.length === 1 ? 'y' : 'ies'}: ${anomalies.join('; ')}`);
+		}
+
+		const prefix = verdict === 'critical'
+			? 'I am in a critical state.'
+			: 'I am degraded but still operating.';
+		return `${prefix} ${parts.join(', and ')}.`;
+	}
+
+	private _persistAssessment(assessment: SelfAssessment): void {
+		this.hypergraphStore.addNode({
+			id: assessment.id,
+			node_type: ASSESSMENT_NODE_TYPE,
+			content: assessment.narrative,
+			links: [],
+			metadata: {
+				verdict: assessment.verdict,
+				selfConfidence: assessment.selfConfidence,
+				anomalies: assessment.anomalies,
+				observations: assessment.observations,
+				timestamp: assessment.timestamp
+			},
+			salience_score: VERDICT_SALIENCE[assessment.verdict]
+		});
+	}
+}

--- a/src/sql/workbench/services/zonecog/browser/autognosisService.ts
+++ b/src/sql/workbench/services/zonecog/browser/autognosisService.ts
@@ -199,7 +199,12 @@ export class AutognosisService extends Disposable implements IAutognosisService 
 	}
 
 	private _computeSelfConfidence(observations: SubsystemObservation[], anomalies: string[]): number {
-		const unhealthyCount = observations.filter(o => !o.healthy).length;
+		// The embodiment observation's `healthy` flag is itself derived from
+		// overall membrane health (see EmbodiedCognitionService.getProprioceptiveState),
+		// so it carries no information beyond the membrane triads already in
+		// `observations` -- counting it here would double-penalize the same
+		// root cause (one unhealthy triad would otherwise cost 0.4, not 0.2).
+		const unhealthyCount = observations.filter(o => o.subsystem !== 'embodiment' && !o.healthy).length;
 		const confidence = 1 - (unhealthyCount * 0.2) - (anomalies.length * 0.1);
 		return Math.max(0, Math.min(1, confidence));
 	}

--- a/src/sql/workbench/services/zonecog/browser/zonecog.contribution.ts
+++ b/src/sql/workbench/services/zonecog/browser/zonecog.contribution.ts
@@ -64,6 +64,8 @@ import { ICollaborativeReasoningService } from 'sql/workbench/services/zonecog/c
 import { CollaborativeReasoningService } from 'sql/workbench/services/zonecog/browser/collaborativeReasoningService';
 import { IAtomSpaceTransportService } from 'sql/workbench/services/zonecog/common/atomSpaceTransport';
 import { AtomSpaceTransportService } from 'sql/workbench/services/zonecog/browser/atomSpaceTransportService';
+import { IAutognosisService } from 'sql/workbench/services/zonecog/common/autognosis';
+import { AutognosisService } from 'sql/workbench/services/zonecog/browser/autognosisService';
 
 // Register the Hypergraph store (dependency of ZoneCogService)
 registerSingleton(IHypergraphStore, HypergraphStore, InstantiationType.Eager);
@@ -192,3 +194,9 @@ registerSingleton(ICollaborativeReasoningService, CollaborativeReasoningService,
 // hypergraph store to the ZoneCog Python bridge's /ingest/atoms endpoint;
 // closes Phase 3.2 "Real AtomSpace transport")
 registerSingleton(IAtomSpaceTransportService, AtomSpaceTransportService, InstantiationType.Eager);
+
+// Register the Autognosis service (self-monitoring meta-cognition
+// synthesizing membrane, embodiment, and analytics state into first-person
+// self-assessments; closes Phase 5.3 "Autognosis self-monitoring
+// capabilities")
+registerSingleton(IAutognosisService, AutognosisService, InstantiationType.Eager);

--- a/src/sql/workbench/services/zonecog/common/autognosis.ts
+++ b/src/sql/workbench/services/zonecog/common/autognosis.ts
@@ -1,0 +1,105 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
+import { Event } from 'vs/base/common/event';
+
+export const IAutognosisService = createDecorator<IAutognosisService>('autognosisService');
+
+// ---------------------------------------------------------------------------
+// Self-assessment types
+// ---------------------------------------------------------------------------
+
+/**
+ * Overall self-assessed health verdict.
+ */
+export type AutognosisVerdict = 'nominal' | 'degraded' | 'critical';
+
+/**
+ * A single subsystem's contribution to a self-assessment, as observed by
+ * the Autognosis service (not measured directly -- it reads the subsystem's
+ * own reported state).
+ */
+export interface SubsystemObservation {
+	/** Subsystem identifier, e.g. a membrane triad name or "embodiment". */
+	subsystem: string;
+	healthy: boolean;
+	/** Human-readable detail backing the healthy/unhealthy verdict. */
+	detail: string;
+}
+
+/**
+ * A point-in-time self-assessment: the cognitive system's introspective
+ * read of its own health, synthesized from the membrane, embodiment, and
+ * analytics subsystems.
+ */
+export interface SelfAssessment {
+	/** Stable hypergraph node id of this assessment. */
+	id: string;
+	timestamp: number;
+	verdict: AutognosisVerdict;
+	/** Self-reported confidence in own reliability, in [0, 1]. */
+	selfConfidence: number;
+	/** Human-readable, first-person reflective summary. */
+	narrative: string;
+	observations: SubsystemObservation[];
+	/** Short descriptions of anomalies detected during this assessment. */
+	anomalies: string[];
+}
+
+/**
+ * Directional trend across recent self-assessments.
+ */
+export type AutognosisTrend = 'improving' | 'stable' | 'degrading';
+
+// ---------------------------------------------------------------------------
+// Service interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Autognosis service.
+ *
+ * Closes the "Autognosis self-monitoring capabilities" roadmap item
+ * (Phase 5.3): a meta-cognitive layer that periodically reflects on the
+ * cognitive system's *own* state by synthesizing signals already reported
+ * by other subsystems (membrane triad health, embodiment proprioception,
+ * and cognitive analytics) into a single self-assessment with a verdict,
+ * a self-confidence score, a first-person narrative, and any detected
+ * anomalies. It does not re-measure raw signals itself -- it interprets
+ * what the rest of the system already reports about itself.
+ *
+ * The service self-wires to `IZoneCogService.onDidProcessQuery`, so every
+ * completed query triggers a fresh self-assessment automatically;
+ * `performSelfAssessment` can also be invoked directly (e.g. from the
+ * Command Palette).
+ */
+export interface IAutognosisService {
+	readonly _serviceBrand: undefined;
+
+	/** Fired whenever a self-assessment completes. */
+	readonly onDidCompleteSelfAssessment: Event<SelfAssessment>;
+
+	/**
+	 * Synthesize a fresh self-assessment from current subsystem state,
+	 * persist it as a SelfAssessment hypergraph node, append it to the
+	 * bounded history, and fire `onDidCompleteSelfAssessment`.
+	 */
+	performSelfAssessment(): SelfAssessment;
+
+	/** The most recent self-assessment, if any has been performed. */
+	getLatestAssessment(): SelfAssessment | undefined;
+
+	/** Retained self-assessment history, most recent first. */
+	getAssessmentHistory(limit?: number): SelfAssessment[];
+
+	/**
+	 * Directional trend in self-confidence across the retained history.
+	 * Returns 'stable' when fewer than two assessments have been recorded.
+	 */
+	getTrend(): AutognosisTrend;
+
+	/** Clear the assessment history and remove persisted SelfAssessment nodes. */
+	reset(): void;
+}

--- a/src/sql/workbench/services/zonecog/test/browser/autognosisService.test.ts
+++ b/src/sql/workbench/services/zonecog/test/browser/autognosisService.test.ts
@@ -123,7 +123,10 @@ suite('Autognosis Service Tests', () => {
 
 		const assessment = autognosisService.performSelfAssessment();
 		assert.strictEqual(assessment.verdict, 'critical');
-		assert.ok(assessment.selfConfidence < 1);
+		// Exactly one unhealthy triad should cost exactly one 0.2 penalty: the
+		// embodiment observation mirrors membrane health and must not be
+		// double-counted (see AutognosisService._computeSelfConfidence).
+		assert.strictEqual(assessment.selfConfidence, 0.8);
 		const somaticObservation = assessment.observations.find(o => o.subsystem === 'somatic');
 		assert.ok(somaticObservation);
 		assert.strictEqual(somaticObservation!.healthy, false);

--- a/src/sql/workbench/services/zonecog/test/browser/autognosisService.test.ts
+++ b/src/sql/workbench/services/zonecog/test/browser/autognosisService.test.ts
@@ -1,0 +1,191 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { IAutognosisService, SelfAssessment } from 'sql/workbench/services/zonecog/common/autognosis';
+import { AutognosisService } from 'sql/workbench/services/zonecog/browser/autognosisService';
+import { IZoneCogService, IHypergraphStore, ICognitiveMembraneService, MembraneTriad } from 'sql/workbench/services/zonecog/common/zonecogService';
+import { ZoneCogService } from 'sql/workbench/services/zonecog/browser/zonecogService';
+import { HypergraphStore } from 'sql/workbench/services/zonecog/browser/hypergraphStore';
+import { CognitiveMembraneService } from 'sql/workbench/services/zonecog/browser/cognitiveMembraneService';
+import { ILLMProviderService } from 'sql/workbench/services/zonecog/common/llmProvider';
+import { LLMProviderService } from 'sql/workbench/services/zonecog/browser/llmProviderService';
+import { IEmbodiedCognitionService } from 'sql/workbench/services/zonecog/common/embodiedCognition';
+import { EmbodiedCognitionService } from 'sql/workbench/services/zonecog/browser/embodiedCognitionService';
+import { ICognitiveWorkspaceService } from 'sql/workbench/services/zonecog/common/cognitiveWorkspace';
+import { CognitiveWorkspaceService } from 'sql/workbench/services/zonecog/browser/cognitiveWorkspaceService';
+import { IECANAttentionService } from 'sql/workbench/services/zonecog/common/ecanAttention';
+import { ECANAttentionService } from 'sql/workbench/services/zonecog/browser/ecanAttentionService';
+import { IDTESNService } from 'sql/workbench/services/zonecog/common/dtesn';
+import { DTESNService } from 'sql/workbench/services/zonecog/browser/dtesnService';
+import { ICognitiveAnalyticsService } from 'sql/workbench/services/zonecog/common/cognitiveAnalytics';
+import { CognitiveAnalyticsService } from 'sql/workbench/services/zonecog/browser/cognitiveAnalyticsService';
+import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
+import { ILogService, NullLogService } from 'vs/platform/log/common/log';
+
+suite('Autognosis Service Tests', () => {
+
+	let instantiationService: TestInstantiationService;
+	let autognosisService: IAutognosisService;
+	let membraneService: CognitiveMembraneService;
+	let embodiedService: EmbodiedCognitionService;
+	let zonecogService: ZoneCogService;
+	let hypergraphStore: HypergraphStore;
+
+	setup(async () => {
+		instantiationService = new TestInstantiationService();
+		instantiationService.stub(ILogService, new NullLogService());
+
+		hypergraphStore = instantiationService.createInstance(HypergraphStore);
+		instantiationService.stub(IHypergraphStore, hypergraphStore);
+
+		membraneService = instantiationService.createInstance(CognitiveMembraneService);
+		instantiationService.stub(ICognitiveMembraneService, membraneService);
+
+		const llmService = instantiationService.createInstance(LLMProviderService);
+		instantiationService.stub(ILLMProviderService, llmService);
+
+		embodiedService = instantiationService.createInstance(EmbodiedCognitionService);
+		instantiationService.stub(IEmbodiedCognitionService, embodiedService);
+
+		const workspaceService = instantiationService.createInstance(CognitiveWorkspaceService);
+		instantiationService.stub(ICognitiveWorkspaceService, workspaceService);
+
+		const ecanService = instantiationService.createInstance(ECANAttentionService);
+		instantiationService.stub(IECANAttentionService, ecanService);
+
+		const dtesnService = instantiationService.createInstance(DTESNService);
+		instantiationService.stub(IDTESNService, dtesnService);
+
+		zonecogService = instantiationService.createInstance(ZoneCogService);
+		instantiationService.stub(IZoneCogService, zonecogService);
+		await zonecogService.initialize();
+
+		const analyticsService = instantiationService.createInstance(CognitiveAnalyticsService);
+		instantiationService.stub(ICognitiveAnalyticsService, analyticsService);
+
+		autognosisService = instantiationService.createInstance(AutognosisService);
+	});
+
+	// --- Initial state ---
+
+	test('should start with no assessment history', () => {
+		assert.strictEqual(autognosisService.getLatestAssessment(), undefined);
+		assert.deepStrictEqual(autognosisService.getAssessmentHistory(), []);
+		assert.strictEqual(autognosisService.getTrend(), 'stable');
+	});
+
+	// --- Nominal assessment ---
+
+	test('should report a nominal verdict when all subsystems are healthy', () => {
+		const assessment = autognosisService.performSelfAssessment();
+
+		assert.strictEqual(assessment.verdict, 'nominal');
+		assert.strictEqual(assessment.selfConfidence, 1);
+		assert.strictEqual(assessment.anomalies.length, 0);
+		assert.ok(assessment.observations.length >= 4); // 3 membrane triads + embodiment
+		assert.ok(assessment.observations.every(o => o.healthy));
+	});
+
+	test('should fire onDidCompleteSelfAssessment', () => {
+		let fired: SelfAssessment | undefined;
+		autognosisService.onDidCompleteSelfAssessment(a => fired = a);
+
+		const assessment = autognosisService.performSelfAssessment();
+		assert.ok(fired);
+		assert.strictEqual(fired!.id, assessment.id);
+	});
+
+	test('should persist the assessment as a SelfAssessment hypergraph node', () => {
+		const assessment = autognosisService.performSelfAssessment();
+
+		const node = hypergraphStore.getNode(assessment.id);
+		assert.ok(node);
+		assert.strictEqual(node!.node_type, 'SelfAssessment');
+		assert.strictEqual(node!.metadata['verdict'], 'nominal');
+	});
+
+	test('should trigger a self-assessment automatically after a query is processed', async () => {
+		assert.strictEqual(autognosisService.getLatestAssessment(), undefined);
+		await zonecogService.processQuery('What tables exist in this database?');
+		assert.ok(autognosisService.getLatestAssessment());
+	});
+
+	// --- Degraded / critical assessment ---
+
+	test('should report critical when a membrane triad is unhealthy', () => {
+		const triad: MembraneTriad = 'somatic';
+		for (let i = 0; i < 10; i++) {
+			membraneService.recordError(triad, `synthetic error ${i}`);
+		}
+
+		const assessment = autognosisService.performSelfAssessment();
+		assert.strictEqual(assessment.verdict, 'critical');
+		assert.ok(assessment.selfConfidence < 1);
+		const somaticObservation = assessment.observations.find(o => o.subsystem === 'somatic');
+		assert.ok(somaticObservation);
+		assert.strictEqual(somaticObservation!.healthy, false);
+	});
+
+	test('should report degraded with an anomaly on sustained high cognitive load', () => {
+		// EmbodiedCognitionService estimates load from percepts+actions in the
+		// last 30s: min(1, (recentPercepts / 10 + recentActions / 5) / 2). 21
+		// near-simultaneous percepts drive load to 1.0, well past the 0.85 anomaly
+		// threshold, with no actions and no membrane errors recorded.
+		for (let i = 0; i < 21; i++) {
+			embodiedService.perceive('query', `query ${i}`, 'SELECT * FROM huge_table', 1);
+		}
+		assert.ok(embodiedService.getProprioceptiveState().cognitiveLoad > 0.85);
+
+		const assessment = autognosisService.performSelfAssessment();
+		assert.strictEqual(assessment.verdict, 'degraded');
+		assert.ok(assessment.anomalies.some(a => a.includes('cognitive load')));
+	});
+
+	// --- History & trend ---
+
+	test('should retain assessment history, most recent first', () => {
+		autognosisService.performSelfAssessment();
+		autognosisService.performSelfAssessment();
+		const third = autognosisService.performSelfAssessment();
+
+		const history = autognosisService.getAssessmentHistory();
+		assert.strictEqual(history.length, 3);
+		assert.strictEqual(history[0].id, third.id);
+	});
+
+	test('should honor the history limit', () => {
+		autognosisService.performSelfAssessment();
+		autognosisService.performSelfAssessment();
+		autognosisService.performSelfAssessment();
+
+		assert.strictEqual(autognosisService.getAssessmentHistory(1).length, 1);
+	});
+
+	test('should report a degrading trend when confidence declines', () => {
+		autognosisService.performSelfAssessment();
+		autognosisService.performSelfAssessment();
+
+		for (let i = 0; i < 10; i++) {
+			membraneService.recordError('cerebral', `synthetic error ${i}`);
+		}
+		autognosisService.performSelfAssessment();
+
+		assert.strictEqual(autognosisService.getTrend(), 'degrading');
+	});
+
+	// --- Reset ---
+
+	test('reset should clear history and remove persisted nodes', () => {
+		const assessment = autognosisService.performSelfAssessment();
+		assert.ok(hypergraphStore.getNode(assessment.id));
+
+		autognosisService.reset();
+
+		assert.deepStrictEqual(autognosisService.getAssessmentHistory(), []);
+		assert.strictEqual(autognosisService.getLatestAssessment(), undefined);
+		assert.strictEqual(hypergraphStore.getNode(assessment.id), undefined);
+	});
+});


### PR DESCRIPTION
## Description

Implements the next unchecked item of `docs/ZONECOG_ROADMAP.md` Phase 5.3 "EchoCog Integration": **Autognosis self-monitoring capabilities** (closes #69).

Adds `IAutognosisService`/`AutognosisService`, a meta-cognitive layer that does not measure anything new itself — it synthesizes signals already reported by three existing subsystems into a first-person self-assessment:

- **Cognitive Membrane** (`ICognitiveMembraneService`) — Cerebral/Somatic/Autonomic triad health
- **Embodied Cognition** (`IEmbodiedCognitionService`) — proprioceptive cognitive load, focus, health
- **Cognitive Analytics** (`ICognitiveAnalyticsService`) — LLM fallback ratio, DTESN convergence

Each `SelfAssessment` carries a `verdict` (`nominal` / `degraded` / `critical`), a `selfConfidence` score in `[0, 1]`, a human-readable first-person `narrative`, the per-subsystem `observations`, and any detected `anomalies` (sustained high cognitive load, high LLM fallback ratio, non-converging DTESN training).

The service self-wires to `IZoneCogService.onDidProcessQuery`, so every completed query triggers a fresh self-assessment automatically. Assessments are persisted as `SelfAssessment` hypergraph nodes and retained in a bounded history exposing a confidence `getTrend()` (`improving` / `stable` / `degrading`).

## Code Changes Checklist

- [x] New or updated **unit tests** added — `src/sql/workbench/services/zonecog/test/browser/autognosisService.test.ts`
- [ ] All existing tests pass (`npm run test`) — not run in this environment (monorepo `node_modules` not installed here); relying on CI
- [x] Code follows [contributing guidelines](https://github.com/microsoft/azuredatastudio/blob/main/CONTRIBUTING.md) — matches existing ZoneCog service conventions (interface in `common/`, implementation in `browser/`, DI registration, Command Palette actions)
- [x] No UI regressions introduced — additive only (new service + two new Command Palette actions)
- [x] Logging/telemetry updated if applicable — uses `ILogService` consistent with sibling services
- [ ] Cross-platform support checked (Windows, macOS, Linux if relevant) — pure TypeScript service, no platform-specific code

## Files changed

- `src/sql/workbench/services/zonecog/common/autognosis.ts` (new) — `IAutognosisService` interface and types
- `src/sql/workbench/services/zonecog/browser/autognosisService.ts` (new) — implementation
- `src/sql/workbench/services/zonecog/test/browser/autognosisService.test.ts` (new) — unit tests
- `src/sql/workbench/services/zonecog/browser/zonecog.contribution.ts` — service registration
- `src/sql/workbench/contrib/zonecog/browser/zonecogActions.contribution.ts` — `Zone-Cog: Perform Self-Assessment` and `Zone-Cog: Show Self-Assessment History` Command Palette actions
- `src/sql/workbench/services/zonecog/README.md` — new Autognosis section
- `docs/ZONECOG_ROADMAP.md` — checked off the roadmap item


---
_Generated by [Claude Code](https://claude.ai/code/session_01XMwZQuzapd6wphNGGp4rZo)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive ZoneCog meta-cognition layer with tests; only notable behavior is an extra self-assessment per processed query and hypergraph node writes.
> 
> **Overview**
> Adds **Autognosis** (Phase 5.3): `IAutognosisService` / `AutognosisService` synthesizes membrane triad health, embodiment proprioception, and cognitive analytics into a `SelfAssessment` (verdict, self-confidence, narrative, anomalies). Assessments run on every `onDidProcessQuery`, persist as `SelfAssessment` hypergraph nodes, and keep bounded history with `getTrend()`.
> 
> Registers the service in `zonecog.contribution.ts`, documents it in the ZoneCog README, marks the roadmap item complete, and adds Command Palette actions **Perform Self-Assessment** and **Show Self-Assessment History**. Includes `autognosisService.test.ts` and minor `allow-any-unicode-next-line` comments in the ZoneCog smoke script for failure output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48ee46ac02ffdc4d532828c26ff247f3f2c64915. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->