### PR TITLE
feat(zonecog): SQLite-backed AtomSpace persistence for the standalone bridge

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -69,7 +69,7 @@ jobs:
         run: yarn --frozen-lockfile --network-timeout 180000
 
       - name: Install Python bridge dependencies
-        run: pip install -r azure_integration/requirements.txt pytest
+        run: pip install -r azure_integration/requirements.txt pytest httpx
 
       - name: Run Python Bridge Tests
         run: python -m pytest azure_integration/tests/ -v --tb=short

--- a/azure_integration/README.md
+++ b/azure_integration/README.md
@@ -15,12 +15,25 @@ python -m azure_integration.cli serve   # or: python -m azure_integration.data_s
 ```
 
 Reads `HOST` (default `0.0.0.0` in Docker, `127.0.0.1` otherwise), `PORT`
-(default `7807`), `ATOMSPACE_MODE` (`local` or `http`), and `ATOMSPACE_URL`
-from the environment. The default `local` backend keeps a real in-process atom
-graph and performs deterministic structural reasoning; `http` forwards to the
-configured AtomSpace service. Endpoints: `GET /health`, `GET /status`,
-`POST /ingest/schema`, `POST /ingest/table`, `POST /ingest/atoms`,
-`POST /reason`.
+(default `7807`), `ATOMSPACE_MODE` (`local` or `http`), `ATOMSPACE_URL`, and
+`ATOMSPACE_PERSIST_PATH` from the environment. The default `local` backend
+keeps a real in-process atom graph and performs deterministic structural
+reasoning; `http` forwards to the configured AtomSpace service. Endpoints:
+`GET /health`, `GET /status`, `GET /atoms`, `POST /ingest/schema`,
+`POST /ingest/table`, `POST /ingest/atoms`, `POST /reason`.
+
+### Persistence
+
+By default the `local` backend's atom graph lives only in process memory and
+is lost on restart. Setting `ATOMSPACE_PERSIST_PATH` to a file path (e.g.
+`/data/atomspace.db`) switches it to a SQLite-backed store
+(`azure_integration/atomspace_store.py`): every `upsert` is written through to
+the file, and the graph is reloaded from it on the next startup. This has no
+effect in `http` mode, where the remote AtomSpace backend owns durability.
+
+```bash
+ATOMSPACE_PERSIST_PATH=/data/atomspace.db python -m azure_integration.cli serve
+```
 
 ## Headless CLI
 
@@ -34,6 +47,7 @@ python -m azure_integration.cli ingest-table table.json
 python -m azure_integration.cli ingest-atoms atoms.json
 python -m azure_integration.cli reason reason.json
 python -m azure_integration.cli status
+python -m azure_integration.cli list-atoms
 ```
 
 Each subcommand (other than `health`/`status`/`serve`) reads one JSON document
@@ -60,6 +74,14 @@ The image installs only `azure_integration/requirements.txt` and copies the
 `azure_integration` package — no ADS build toolchain — and defaults to
 `serve`. Override the command to run a one-off CLI invocation instead, e.g.
 `docker run --rm -v "$PWD:/data" zonecog-bridge ingest-schema /data/schema.json`.
+
+To retain the atom graph across container restarts, mount a volume and set
+`ATOMSPACE_PERSIST_PATH` to a file inside it:
+
+```bash
+docker run -p 7807:7807 -e ATOMSPACE_PERSIST_PATH=/data/atomspace.db \
+    -v zonecog-data:/data zonecog-bridge
+```
 
 ## Tests
 

--- a/azure_integration/atomspace_store.py
+++ b/azure_integration/atomspace_store.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import threading
 from typing import Any, Dict, Iterable, Tuple
 
 _SCHEMA = """
@@ -36,18 +37,26 @@ class SqliteAtomStore:
 
     def __init__(self, path: str) -> None:
         self.path = path
-        self._conn = sqlite3.connect(self.path, isolation_level=None)
-        self._conn.executescript(_SCHEMA)
+        # FastAPI's sync `def` route handlers run each request in a worker
+        # threadpool, not the thread the store was constructed on, so the
+        # sqlite3 default of `check_same_thread=True` would raise
+        # `ProgrammingError` on every HTTP request once persistence is
+        # enabled. Allow cross-thread use and serialize access ourselves.
+        self._lock = threading.Lock()
+        self._conn = sqlite3.connect(self.path, isolation_level=None, check_same_thread=False)
+        with self._lock:
+            self._conn.executescript(_SCHEMA)
 
     def load_all(self) -> Tuple[Dict[str, Dict[str, Any]], Dict[str, Dict[str, Any]]]:
-        nodes = {
-            row[0]: json.loads(row[1])
-            for row in self._conn.execute("SELECT uuid, data FROM atomspace_nodes")
-        }
-        links = {
-            row[0]: json.loads(row[1])
-            for row in self._conn.execute("SELECT uuid, data FROM atomspace_links")
-        }
+        with self._lock:
+            nodes = {
+                row[0]: json.loads(row[1])
+                for row in self._conn.execute("SELECT uuid, data FROM atomspace_nodes")
+            }
+            links = {
+                row[0]: json.loads(row[1])
+                for row in self._conn.execute("SELECT uuid, data FROM atomspace_links")
+            }
         return nodes, links
 
     def upsert_nodes(self, atoms: Iterable[Dict[str, Any]]) -> None:
@@ -60,11 +69,13 @@ class SqliteAtomStore:
         rows = [(atom["uuid"], json.dumps(atom)) for atom in atoms]
         if not rows:
             return
-        self._conn.executemany(
-            f"INSERT INTO {table} (uuid, data) VALUES (?, ?) "
-            "ON CONFLICT(uuid) DO UPDATE SET data = excluded.data",
-            rows,
-        )
+        with self._lock:
+            self._conn.executemany(
+                f"INSERT INTO {table} (uuid, data) VALUES (?, ?) "
+                "ON CONFLICT(uuid) DO UPDATE SET data = excluded.data",
+                rows,
+            )
 
     def close(self) -> None:
-        self._conn.close()
+        with self._lock:
+            self._conn.close()

--- a/azure_integration/atomspace_store.py
+++ b/azure_integration/atomspace_store.py
@@ -1,0 +1,70 @@
+"""Durable local AtomSpace storage for the ZoneCog Python bridge.
+
+`AtomSpaceAdapter` in `data_studio_bridge.py` keeps its `local`-mode atom
+graph in a plain Python dict, which is lost whenever the bridge process
+restarts. This module adds an optional SQLite-backed store so a standalone
+bridge instance (Phase 5.2's headless/Docker deployment) can retain its
+ingested atoms across restarts without any extra runtime dependency — only
+the standard library `sqlite3` module is used.
+
+Enabled by setting the `ATOMSPACE_PERSIST_PATH` environment variable to a
+file path; when unset, `AtomSpaceAdapter` keeps its current in-memory-only
+behavior.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any, Dict, Iterable, Tuple
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS atomspace_nodes (
+    uuid TEXT PRIMARY KEY,
+    data TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS atomspace_links (
+    uuid TEXT PRIMARY KEY,
+    data TEXT NOT NULL
+);
+"""
+
+
+class SqliteAtomStore:
+    """Persists AtomSpace node/link atoms (as JSON blobs keyed by uuid) to a
+    SQLite file, so a `local`-mode `AtomSpaceAdapter` can reload its graph
+    after a process restart."""
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self._conn = sqlite3.connect(self.path, isolation_level=None)
+        self._conn.executescript(_SCHEMA)
+
+    def load_all(self) -> Tuple[Dict[str, Dict[str, Any]], Dict[str, Dict[str, Any]]]:
+        nodes = {
+            row[0]: json.loads(row[1])
+            for row in self._conn.execute("SELECT uuid, data FROM atomspace_nodes")
+        }
+        links = {
+            row[0]: json.loads(row[1])
+            for row in self._conn.execute("SELECT uuid, data FROM atomspace_links")
+        }
+        return nodes, links
+
+    def upsert_nodes(self, atoms: Iterable[Dict[str, Any]]) -> None:
+        self._upsert("atomspace_nodes", atoms)
+
+    def upsert_links(self, atoms: Iterable[Dict[str, Any]]) -> None:
+        self._upsert("atomspace_links", atoms)
+
+    def _upsert(self, table: str, atoms: Iterable[Dict[str, Any]]) -> None:
+        rows = [(atom["uuid"], json.dumps(atom)) for atom in atoms]
+        if not rows:
+            return
+        self._conn.executemany(
+            f"INSERT INTO {table} (uuid, data) VALUES (?, ?) "
+            "ON CONFLICT(uuid) DO UPDATE SET data = excluded.data",
+            rows,
+        )
+
+    def close(self) -> None:
+        self._conn.close()

--- a/azure_integration/cli.py
+++ b/azure_integration/cli.py
@@ -43,6 +43,10 @@ def cmd_status(app: BridgeApp, args: argparse.Namespace) -> Dict[str, Any]:
     return app.status()
 
 
+def cmd_list_atoms(app: BridgeApp, args: argparse.Namespace) -> Dict[str, Any]:
+    return app.list_atoms()
+
+
 def cmd_ingest_schema(app: BridgeApp, args: argparse.Namespace) -> Dict[str, Any]:
     payload = _read_json(args.input)
     return app.ingest_schema(IngestSchemaRequest(**payload))
@@ -88,6 +92,11 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_status = sub.add_parser("status", help="report processed batch count and last request id")
     p_status.set_defaults(func=cmd_status)
+
+    p_list_atoms = sub.add_parser(
+        "list-atoms", help="list all nodes/links currently held by the AtomSpace adapter"
+    )
+    p_list_atoms.set_defaults(func=cmd_list_atoms)
 
     p_schema = sub.add_parser(
         "ingest-schema", help="ingest a {tables, foreign_keys} JSON document"

--- a/azure_integration/data_studio_bridge.py
+++ b/azure_integration/data_studio_bridge.py
@@ -87,6 +87,13 @@ class AtomSpaceAdapter:
             self._store = SqliteAtomStore(self.persist_path)
             self._nodes, self._links = self._store.load_all()
 
+    @property
+    def persisted(self) -> bool:
+        """Whether upserts are actually being written through to a durable
+        store — not just whether ATOMSPACE_PERSIST_PATH happens to be set,
+        since persistence only applies in `local` mode."""
+        return self._store is not None
+
     def upsert(self, batch: AtomBatch) -> Dict[str, Any]:
         if self.mode == "local":
             nodes = batch.get("nodes", [])
@@ -99,7 +106,7 @@ class AtomSpaceAdapter:
             return {
                 "status": "ok",
                 "backend": "local",
-                "persisted": self._store is not None,
+                "persisted": self.persisted,
                 "nodes": len(nodes),
                 "links": len(links),
                 "total_nodes": len(self._nodes),
@@ -152,7 +159,7 @@ class AtomSpaceAdapter:
         return {
             "status": "ok",
             "backend": self.mode,
-            "persisted": self._store is not None,
+            "persisted": self.persisted,
             "nodes": list(self._nodes.values()),
             "links": list(self._links.values()),
         }
@@ -228,7 +235,7 @@ class BridgeApp:
 
     def health(self) -> Dict[str, Any]:
         capabilities = ["ingest-schema", "ingest-table", "ingest-atoms", "reason", "list-atoms"]
-        if self.adapter.persist_path:
+        if self.adapter.persisted:
             capabilities.append("persist")
         return {
             "status": "ok",
@@ -276,7 +283,7 @@ class BridgeApp:
             "last_request_id": self.last_request_id,
             "protocol_version": PROTOCOL_VERSION,
             "backend": self.adapter.mode,
-            "persisted": self.adapter.persist_path is not None,
+            "persisted": self.adapter.persisted,
         }
 
 

--- a/azure_integration/data_studio_bridge.py
+++ b/azure_integration/data_studio_bridge.py
@@ -17,6 +17,7 @@ except ImportError:  # pragma: no cover
     Field = None  # type: ignore
     uvicorn = None  # type: ignore
 
+from azure_integration.atomspace_store import SqliteAtomStore
 from azure_integration.atomspace_transport import AtomSpaceTransportError, HttpAtomSpaceTransport
 from azure_integration.sql_to_atomspace import AtomBatch, map_rows_to_atoms, map_schema_to_atoms, merge_batches
 
@@ -63,13 +64,16 @@ class StatusResponse(BaseModel):  # type: ignore
     last_request_id: Optional[str]
     protocol_version: str
     backend: str
+    persisted: bool
 
 
 class AtomSpaceAdapter:
     def __init__(self) -> None:
         self.mode = os.environ.get("ATOMSPACE_MODE", "local")
         self.endpoint = os.environ.get("ATOMSPACE_URL")
+        self.persist_path = os.environ.get("ATOMSPACE_PERSIST_PATH")
         self._transport: Optional[HttpAtomSpaceTransport] = None
+        self._store: Optional[SqliteAtomStore] = None
         self._nodes: Dict[str, Dict[str, Any]] = {}
         self._links: Dict[str, Dict[str, Any]] = {}
         if self.mode == "http" and not self.endpoint:
@@ -79,6 +83,9 @@ class AtomSpaceAdapter:
             self._transport = HttpAtomSpaceTransport(self.endpoint)
         elif self.mode != "local":
             raise ValueError(f"Unsupported ATOMSPACE_MODE: {self.mode}")
+        if self.mode == "local" and self.persist_path:
+            self._store = SqliteAtomStore(self.persist_path)
+            self._nodes, self._links = self._store.load_all()
 
     def upsert(self, batch: AtomBatch) -> Dict[str, Any]:
         if self.mode == "local":
@@ -86,9 +93,13 @@ class AtomSpaceAdapter:
             links = batch.get("links", [])
             self._store_atoms(self._nodes, nodes, "node")
             self._store_atoms(self._links, links, "link")
+            if self._store is not None:
+                self._store.upsert_nodes(nodes)
+                self._store.upsert_links(links)
             return {
                 "status": "ok",
                 "backend": "local",
+                "persisted": self._store is not None,
                 "nodes": len(nodes),
                 "links": len(links),
                 "total_nodes": len(self._nodes),
@@ -136,6 +147,15 @@ class AtomSpaceAdapter:
             except AtomSpaceTransportError as exc:
                 raise RuntimeError(str(exc)) from exc
         raise RuntimeError(f"Unsupported AtomSpace backend: {self.mode}")
+
+    def list_atoms(self) -> Dict[str, Any]:
+        return {
+            "status": "ok",
+            "backend": self.mode,
+            "persisted": self._store is not None,
+            "nodes": list(self._nodes.values()),
+            "links": list(self._links.values()),
+        }
 
     @staticmethod
     def _store_atoms(target: Dict[str, Dict[str, Any]], atoms: List[Dict[str, Any]], kind: str) -> None:
@@ -207,12 +227,15 @@ class BridgeApp:
         self.last_request_id: Optional[str] = None
 
     def health(self) -> Dict[str, Any]:
+        capabilities = ["ingest-schema", "ingest-table", "ingest-atoms", "reason", "list-atoms"]
+        if self.adapter.persist_path:
+            capabilities.append("persist")
         return {
             "status": "ok",
             "time": datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z"),
             "protocol_version": PROTOCOL_VERSION,
             "backend": self.adapter.mode,
-            "capabilities": ["ingest-schema", "ingest-table", "ingest-atoms", "reason"],
+            "capabilities": capabilities,
         }
 
     def ingest_schema(self, req: IngestSchemaRequest) -> Dict[str, Any]:
@@ -243,6 +266,9 @@ class BridgeApp:
         self.last_request_id = str(uuid.uuid4())
         return {"cognitive": cog, "adapter": res}
 
+    def list_atoms(self) -> Dict[str, Any]:
+        return self.adapter.list_atoms()
+
     def status(self) -> Dict[str, Any]:
         return {
             "status": "ok",
@@ -250,6 +276,7 @@ class BridgeApp:
             "last_request_id": self.last_request_id,
             "protocol_version": PROTOCOL_VERSION,
             "backend": self.adapter.mode,
+            "persisted": self.adapter.persist_path is not None,
         }
 
 
@@ -277,6 +304,10 @@ if FastAPI:
     @app.post("/reason")
     def post_reason(req: ReasonRequest) -> Dict[str, Any]:
         return app_impl.reason(req)
+
+    @app.get("/atoms")
+    def get_atoms() -> Dict[str, Any]:
+        return app_impl.list_atoms()
 
     @app.get("/status", response_model=StatusResponse)  # type: ignore
     def get_status() -> Dict[str, Any]:

--- a/azure_integration/tests/test_atomspace_store.py
+++ b/azure_integration/tests/test_atomspace_store.py
@@ -1,0 +1,73 @@
+"""Tests for the SQLite-backed AtomSpace persistence store."""
+from __future__ import annotations
+
+import os
+
+from azure_integration.atomspace_store import SqliteAtomStore
+
+
+class TestSqliteAtomStore:
+    def test_new_store_loads_empty(self, tmp_path: "os.PathLike[str]") -> None:
+        store = SqliteAtomStore(str(tmp_path / "atoms.db"))
+        nodes, links = store.load_all()
+        assert nodes == {}
+        assert links == {}
+        store.close()
+
+    def test_upsert_and_reload_nodes(self, tmp_path: "os.PathLike[str]") -> None:
+        path = str(tmp_path / "atoms.db")
+        store = SqliteAtomStore(path)
+        store.upsert_nodes([{"uuid": "n1", "node_type": "TableNode", "content": "users"}])
+        store.close()
+
+        reopened = SqliteAtomStore(path)
+        nodes, links = reopened.load_all()
+        assert nodes == {"n1": {"uuid": "n1", "node_type": "TableNode", "content": "users"}}
+        assert links == {}
+        reopened.close()
+
+    def test_upsert_and_reload_links(self, tmp_path: "os.PathLike[str]") -> None:
+        path = str(tmp_path / "atoms.db")
+        store = SqliteAtomStore(path)
+        store.upsert_links([{"uuid": "l1", "link_type": "ForeignKeyLink", "out": ["n1", "n2"]}])
+        store.close()
+
+        reopened = SqliteAtomStore(path)
+        _, links = reopened.load_all()
+        assert links == {"l1": {"uuid": "l1", "link_type": "ForeignKeyLink", "out": ["n1", "n2"]}}
+        reopened.close()
+
+    def test_upsert_overwrites_existing_uuid(self, tmp_path: "os.PathLike[str]") -> None:
+        path = str(tmp_path / "atoms.db")
+        store = SqliteAtomStore(path)
+        store.upsert_nodes([{"uuid": "n1", "content": "v1"}])
+        store.upsert_nodes([{"uuid": "n1", "content": "v2"}])
+        nodes, _ = store.load_all()
+        assert nodes["n1"]["content"] == "v2"
+        store.close()
+
+    def test_upsert_empty_iterable_is_a_noop(self, tmp_path: "os.PathLike[str]") -> None:
+        path = str(tmp_path / "atoms.db")
+        store = SqliteAtomStore(path)
+        store.upsert_nodes([])
+        store.upsert_links([])
+        nodes, links = store.load_all()
+        assert nodes == {}
+        assert links == {}
+        store.close()
+
+    def test_persists_across_multiple_sessions(self, tmp_path: "os.PathLike[str]") -> None:
+        path = str(tmp_path / "atoms.db")
+
+        store1 = SqliteAtomStore(path)
+        store1.upsert_nodes([{"uuid": "n1", "content": "a"}])
+        store1.close()
+
+        store2 = SqliteAtomStore(path)
+        store2.upsert_nodes([{"uuid": "n2", "content": "b"}])
+        store2.close()
+
+        store3 = SqliteAtomStore(path)
+        nodes, _ = store3.load_all()
+        assert set(nodes) == {"n1", "n2"}
+        store3.close()

--- a/azure_integration/tests/test_cli.py
+++ b/azure_integration/tests/test_cli.py
@@ -61,6 +61,7 @@ class TestCommandHandlers:
             "last_request_id": None,
             "protocol_version": "1.0",
             "backend": "local",
+            "persisted": False,
         }
 
     def test_ingest_schema_from_file(self, tmp_path: Path) -> None:
@@ -172,6 +173,7 @@ class TestParser:
         assert set(subparsers_action.choices) == {  # type: ignore[attr-defined]
             "health",
             "status",
+            "list-atoms",
             "ingest-schema",
             "ingest-table",
             "ingest-atoms",

--- a/azure_integration/tests/test_data_studio_bridge.py
+++ b/azure_integration/tests/test_data_studio_bridge.py
@@ -674,6 +674,7 @@ class TestFastAPIEndpoints:
         assert status["processed_batches"] == 2
 
 
+@pytest.mark.skipif(not _has_fastapi, reason="FastAPI not available")
 class TestFastAPIEndpointsWithPersistence:
     """Regression coverage for the exact scenario Cursor Bugbot flagged: FastAPI's
     sync route handlers execute each request in a worker threadpool, distinct

--- a/azure_integration/tests/test_data_studio_bridge.py
+++ b/azure_integration/tests/test_data_studio_bridge.py
@@ -54,6 +54,8 @@ class TestBridgeAppHealth:
         assert result["protocol_version"] == "1.0"
         assert result["backend"] == "local"
         assert "reason" in result["capabilities"]
+        assert "list-atoms" in result["capabilities"]
+        assert "persist" not in result["capabilities"]
 
 
 class TestBridgeAppStatus:
@@ -63,6 +65,7 @@ class TestBridgeAppStatus:
         assert result["status"] == "ok"
         assert result["processed_batches"] == 0
         assert result["last_request_id"] is None
+        assert result["persisted"] is False
 
     def test_status_increments_after_ingest(self) -> None:
         bridge = BridgeApp()
@@ -242,6 +245,16 @@ class TestBridgeAppReason:
         assert bridge.processed_batches == before + 1
 
 
+class TestBridgeAppListAtoms:
+    def test_list_atoms_reflects_ingested_data(self) -> None:
+        bridge = BridgeApp()
+        req = IngestTableRequest(schema="dbo", table="t", primary_key="id", rows=[{"id": 1}])
+        bridge.ingest_table(req)
+        result = bridge.list_atoms()
+        assert result["status"] == "ok"
+        assert len(result["nodes"]) >= 1
+
+
 # ---------------------------------------------------------------------------
 # AtomSpaceAdapter unit tests
 # ---------------------------------------------------------------------------
@@ -283,6 +296,76 @@ class TestAtomSpaceAdapterLocal:
         batch: Dict[str, Any] = {"nodes": [], "links": []}
         result = adapter.reason(batch, mode=None)
         assert result["mode"] == "default"
+
+
+class TestAtomSpaceAdapterPersistence:
+    def setup_method(self) -> None:
+        os.environ.pop("ATOMSPACE_URL", None)
+        os.environ["ATOMSPACE_MODE"] = "local"
+
+    def teardown_method(self) -> None:
+        os.environ.pop("ATOMSPACE_PERSIST_PATH", None)
+
+    def test_upsert_without_persist_path_stays_in_memory_only(self) -> None:
+        os.environ.pop("ATOMSPACE_PERSIST_PATH", None)
+        adapter = AtomSpaceAdapter()
+        batch = map_rows_to_atoms("dbo", "t", [{"id": 1}], primary_key="id")
+        result = adapter.upsert(batch)
+        assert result["persisted"] is False
+
+    def test_upsert_persists_to_sqlite_file(self, tmp_path: Any) -> None:
+        db_path = str(tmp_path / "atoms.db")
+        os.environ["ATOMSPACE_PERSIST_PATH"] = db_path
+        adapter = AtomSpaceAdapter()
+        batch = map_rows_to_atoms("dbo", "t", [{"id": 1, "name": "x"}], primary_key="id")
+        result = adapter.upsert(batch)
+        assert result["persisted"] is True
+
+        # A fresh adapter pointed at the same file reloads the persisted graph.
+        reloaded = AtomSpaceAdapter()
+        assert reloaded._nodes == adapter._nodes
+        assert reloaded._links == adapter._links
+        assert len(reloaded._nodes) == len(batch["nodes"])
+
+    def test_reload_survives_process_restart_simulation(self, tmp_path: Any) -> None:
+        db_path = str(tmp_path / "atoms.db")
+        os.environ["ATOMSPACE_PERSIST_PATH"] = db_path
+
+        first = AtomSpaceAdapter()
+        batch1 = map_rows_to_atoms("dbo", "orders", [{"id": 1}], primary_key="id")
+        first.upsert(batch1)
+        del first  # simulate process exit
+
+        second = AtomSpaceAdapter()
+        batch2 = map_rows_to_atoms("dbo", "orders", [{"id": 2}], primary_key="id")
+        second.upsert(batch2)
+
+        third = AtomSpaceAdapter()
+        assert len(third._nodes) == len(batch1["nodes"]) + len(batch2["nodes"])
+
+
+class TestAtomSpaceAdapterListAtoms:
+    def setup_method(self) -> None:
+        os.environ.pop("ATOMSPACE_URL", None)
+        os.environ.pop("ATOMSPACE_PERSIST_PATH", None)
+        os.environ["ATOMSPACE_MODE"] = "local"
+
+    def test_list_atoms_reflects_upserts(self) -> None:
+        adapter = AtomSpaceAdapter()
+        batch = map_rows_to_atoms("dbo", "t", [{"id": 1}], primary_key="id")
+        adapter.upsert(batch)
+        listed = adapter.list_atoms()
+        assert listed["status"] == "ok"
+        assert listed["backend"] == "local"
+        assert listed["persisted"] is False
+        assert len(listed["nodes"]) == len(batch["nodes"])
+        assert len(listed["links"]) == len(batch["links"])
+
+    def test_list_atoms_empty_by_default(self) -> None:
+        adapter = AtomSpaceAdapter()
+        listed = adapter.list_atoms()
+        assert listed["nodes"] == []
+        assert listed["links"] == []
 
 
 class TestAtomSpaceAdapterInvalidConfiguration:
@@ -452,6 +535,7 @@ class TestFastAPIEndpoints:
         data = response.json()
         assert data["status"] == "ok"
         assert data["processed_batches"] == 0
+        assert data["persisted"] is False
 
     def test_ingest_schema_endpoint(self) -> None:
         payload = {
@@ -500,6 +584,18 @@ class TestFastAPIEndpoints:
         assert data["upsert"]["status"] == "ok"
         assert data["upsert"]["nodes"] == len(batch["nodes"])
         assert data["upsert"]["links"] == len(batch["links"])
+
+    def test_atoms_endpoint_reflects_ingested_data(self) -> None:
+        batch = map_rows_to_atoms("dbo", "orders", [{"id": 1, "amount": 10}], primary_key="id")
+        self.client.post("/ingest/atoms", json={"atoms": batch})
+        response = self.client.get("/atoms")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ok"
+        returned_uuids = {node["uuid"] for node in data["nodes"]}
+        assert {node["uuid"] for node in batch["nodes"]} <= returned_uuids
+        assert len(data["nodes"]) >= len(batch["nodes"])
+        assert len(data["links"]) >= len(batch["links"])
 
     def test_reason_endpoint(self) -> None:
         batch = map_rows_to_atoms("dbo", "orders", [{"id": 1, "qty": 5}], primary_key="id")

--- a/azure_integration/tests/test_data_studio_bridge.py
+++ b/azure_integration/tests/test_data_studio_bridge.py
@@ -343,6 +343,55 @@ class TestAtomSpaceAdapterPersistence:
         third = AtomSpaceAdapter()
         assert len(third._nodes) == len(batch1["nodes"]) + len(batch2["nodes"])
 
+    def test_upsert_from_worker_thread_does_not_raise(self, tmp_path: Any) -> None:
+        # Regression test: FastAPI's sync route handlers run each request in
+        # a worker threadpool, distinct from the thread that constructed the
+        # adapter/store. sqlite3's default check_same_thread=True would raise
+        # ProgrammingError here.
+        import concurrent.futures
+
+        db_path = str(tmp_path / "atoms.db")
+        os.environ["ATOMSPACE_PERSIST_PATH"] = db_path
+        adapter = AtomSpaceAdapter()
+        batch = map_rows_to_atoms("dbo", "t", [{"id": 1}], primary_key="id")
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            result = pool.submit(adapter.upsert, batch).result()
+
+        assert result["persisted"] is True
+        assert len(adapter._nodes) == len(batch["nodes"])
+
+    def test_concurrent_upserts_from_multiple_threads_all_persist(self, tmp_path: Any) -> None:
+        import concurrent.futures
+
+        db_path = str(tmp_path / "atoms.db")
+        os.environ["ATOMSPACE_PERSIST_PATH"] = db_path
+        adapter = AtomSpaceAdapter()
+        batches = [
+            map_rows_to_atoms("dbo", "t", [{"id": i}], primary_key="id") for i in range(8)
+        ]
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
+            results = list(pool.map(adapter.upsert, batches))
+
+        assert all(r["status"] == "ok" for r in results)
+        reloaded = AtomSpaceAdapter()
+        assert len(reloaded._nodes) == sum(len(b["nodes"]) for b in batches)
+
+    def test_http_mode_with_persist_path_set_reports_not_persisted(self, tmp_path: Any) -> None:
+        # ATOMSPACE_PERSIST_PATH only takes effect in `local` mode; in `http`
+        # mode no SqliteAtomStore is ever created, so `persisted` must be
+        # False even though the env var happens to be set.
+        os.environ["ATOMSPACE_MODE"] = "http"
+        os.environ["ATOMSPACE_URL"] = "http://127.0.0.1:1"
+        os.environ["ATOMSPACE_PERSIST_PATH"] = str(tmp_path / "atoms.db")
+        try:
+            adapter = AtomSpaceAdapter()
+            assert adapter.persisted is False
+        finally:
+            os.environ.pop("ATOMSPACE_URL", None)
+            os.environ["ATOMSPACE_MODE"] = "local"
+
 
 class TestAtomSpaceAdapterListAtoms:
     def setup_method(self) -> None:
@@ -623,3 +672,41 @@ class TestFastAPIEndpoints:
 
         status = self.client.get("/status").json()
         assert status["processed_batches"] == 2
+
+
+class TestFastAPIEndpointsWithPersistence:
+    """Regression coverage for the exact scenario Cursor Bugbot flagged: FastAPI's
+    sync route handlers execute each request in a worker threadpool, distinct
+    from the thread that constructs `app_impl`/`AtomSpaceAdapter`/`SqliteAtomStore`
+    at import time. Real HTTP requests (not direct in-process calls) must
+    round-trip through persistence without raising."""
+
+    def setup_method(self) -> None:
+        import azure_integration.data_studio_bridge as bridge_module
+
+        self.bridge_module = bridge_module
+        self._original_app_impl = bridge_module.app_impl
+
+    def teardown_method(self) -> None:
+        self.bridge_module.app_impl = self._original_app_impl
+        os.environ.pop("ATOMSPACE_PERSIST_PATH", None)
+
+    def test_ingest_and_list_atoms_over_http_with_persistence_enabled(self, tmp_path: Any) -> None:
+        os.environ["ATOMSPACE_PERSIST_PATH"] = str(tmp_path / "atoms.db")
+        self.bridge_module.app_impl = self.bridge_module.BridgeApp()
+        client = TestClient(self.bridge_module.app)  # type: ignore[arg-type]
+
+        batch = map_rows_to_atoms("dbo", "orders", [{"id": 1, "amount": 10}], primary_key="id")
+        ingest_response = client.post("/ingest/atoms", json={"atoms": batch})
+        assert ingest_response.status_code == 200
+        assert ingest_response.json()["upsert"]["persisted"] is True
+
+        atoms_response = client.get("/atoms")
+        assert atoms_response.status_code == 200
+        assert atoms_response.json()["persisted"] is True
+
+        status_response = client.get("/status")
+        assert status_response.json()["persisted"] is True
+
+        health_response = client.get("/health")
+        assert "persist" in health_response.json()["capabilities"]

--- a/docs/ZONECOG_ROADMAP.md
+++ b/docs/ZONECOG_ROADMAP.md
@@ -2,7 +2,7 @@
 
 **Ticket**: ECH-4  
 **Status**: Active  
-**Last Updated**: 2026-07-28
+**Last Updated**: 2026-07-31
 
 ## Phase Overview
 
@@ -55,7 +55,7 @@
 - [x] In-memory hypergraph with CRUD operations
 - [x] Salience-based attention scoring
 - [x] Link management (add/remove/query by type)
-- [ ] Persistence layer (future: RocksDB/AtomSpace backend)
+- [x] Persistence layer for the standalone Python bridge — `SqliteAtomStore` (`azure_integration/atomspace_store.py`), wired into `AtomSpaceAdapter`'s `local` mode via `ATOMSPACE_PERSIST_PATH`: every upsert is written through to a SQLite file and reloaded on the next process start; surfaced via `GET /atoms` / `zonecog-bridge list-atoms` and the `status.persisted` flag; the in-browser `IHypergraphStore` remains in-memory (session persistence for that side is `HypergraphPersistenceService`'s IndexedDB store, Phase 3.4)
 
 ### 2.4 Cognitive Membrane Architecture
 - [x] `ICognitiveMembraneService` interface for triad management


### PR DESCRIPTION
## Description

Continues the ZoneCog roadmap (`docs/ZONECOG_ROADMAP.md`, Phase 2.3) by closing the "Persistence layer (future: RocksDB/AtomSpace backend)" gap for the standalone Python bridge.

`AtomSpaceAdapter`'s `local` mode kept its ingested atom graph only in a process-memory dict, so every bridge restart (container recycle, CLI re-invocation, etc.) silently lost all ingested schema/table/reasoning data.

This adds a new `SqliteAtomStore` (`azure_integration/atomspace_store.py`), using only the stdlib `sqlite3` module — no new dependency. It is opt-in via the `ATOMSPACE_PERSIST_PATH` environment variable:

- When set, `AtomSpaceAdapter` loads any previously persisted nodes/links on startup, and every `upsert()` writes through to the SQLite file.
- When unset, behavior is unchanged (in-memory only), so this is fully backward compatible.

Also adds:
- `GET /atoms` HTTP endpoint and `zonecog-bridge list-atoms` CLI subcommand to inspect the current graph.
- A `persisted` boolean on `/status` and on `upsert()` results.
- `"list-atoms"` (and `"persist"` when configured) advertised in `/health` capabilities.
- README/Docker documentation for the new env var, including a volume-mount example for durable container deployments.

The in-browser `IHypergraphStore` (used inside Azure Data Studio itself) is unaffected and remains in-memory for the live session; its own cross-session persistence is the already-shipped `HypergraphPersistenceService` (IndexedDB, Phase 3.4). This PR specifically covers the standalone/headless Python bridge side (Phase 5.2).

## Code Changes Checklist

- [x] New or updated **unit tests** added — `azure_integration/tests/test_atomspace_store.py` (new, 6 cases) plus persistence/list-atoms cases added to `test_data_studio_bridge.py` and updated assertions in `test_cli.py`
- [x] All existing tests pass — `python -m pytest azure_integration/tests/ -v` (86 passed)
- [x] Code follows contributing guidelines
- [x] No UI regressions introduced — Python-only change, no TypeScript/UI touched
- [x] Logging/telemetry updated if applicable — N/A
- [x] Cross-platform support checked — stdlib `sqlite3` only, no platform-specific code

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/azuredatastudio/blob/main/.github/REVIEW_GUIDELINES.md)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wovjbsr3VNB4esApFFtd8J)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Opt-in persistence changes how ingested graph data survives restarts and adds SQLite concurrency paths, though defaults are unchanged and coverage targets thread-pool usage.
> 
> **Overview**
> Adds **optional durable storage** for the ZoneCog Python bridge’s `local` AtomSpace graph via **`ATOMSPACE_PERSIST_PATH`**: a new stdlib **`SqliteAtomStore`** loads nodes/links on startup and **write-throughs every upsert**; unset env keeps in-memory-only behavior.
> 
> Exposes **`GET /atoms`**, the **`list-atoms`** CLI subcommand, and a **`persisted`** flag on **`/status`**, upsert responses, and **`/health`** capabilities (including **`persist`** when enabled). **`http`** mode ignores the persist path.
> 
> Docs cover Docker volume mounts; CI installs **`httpx`** for tests; roadmap marks bridge persistence complete. Tests cover SQLite round-trips, multi-threaded upserts (FastAPI worker threads), and HTTP with persistence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c13965b28fdf4cc7e5b166e3db7f1ed76d52830. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->