### PR TITLE
Claude/gallant clarke wg0irh

### DIFF
--- a/docs/ZONECOG_ROADMAP.md
+++ b/docs/ZONECOG_ROADMAP.md
@@ -262,9 +262,9 @@
 - [x] Docker container for cognitive services — `azure_integration/Dockerfile` (standalone `python:3.11-slim` image, `HEALTHCHECK` via `azure_integration/healthcheck.py`), documented in `azure_integration/README.md`
 
 ### 5.3 EchoCog Integration
-- [ ] Deep integration with Aphrodite Engine for LLM inference
-- [ ] OpenCog Hyperon AtomSpace backend
-- [ ] FlareCog distributed cognitive processing
+- [x] Deep integration with Aphrodite Engine for LLM inference (issue #77) — `AphroditeService` LoRA adapter loading/unloading/listing (`loadAdapter`/`unloadAdapter`/`listAdapters`/`getActiveAdapter`), per-request telemetry ring buffer with `getTelemetry()`/`onDidUpdateTelemetry` (latency, tokens/sec, error rate), automatic multi-model fallback chain on `complete()` failure (`AphroditeConfig.fallbackModels`), structured JSON-schema output passthrough (`AphroditeCompletionRequest.responseFormat` → `guided_json`), batched + LRU-bounded embedding indexing in `HypergraphSemanticSearchService` (`indexAll()`/`search()` now chunk uncached-node embedding requests by `maxBatchSize` instead of one call per node), and `Zone-Cog: Load LoRA Adapter` / `Swap Active Model` / `Show Aphrodite Performance Telemetry` Command Palette actions; A/B model-variant comparison framework remains future work
+- [ ] OpenCog Hyperon AtomSpace backend (issue #78)
+- [ ] FlareCog distributed cognitive processing (issue #79)
 - [x] Autognosis self-monitoring capabilities — `IAutognosisService`/`AutognosisService` (meta-cognitive layer that synthesizes membrane triad health, embodiment proprioception, and cognitive analytics into a first-person `SelfAssessment` with a verdict, self-confidence score, and detected anomalies; self-wires to `IZoneCogService.onDidProcessQuery` so every processed query triggers a fresh assessment, persisted as `SelfAssessment` hypergraph nodes; `Zone-Cog: Perform Self-Assessment` and `Zone-Cog: Show Self-Assessment History` Command Palette actions)
 
 ---

--- a/src/sql/workbench/contrib/zonecog/browser/zonecogActions.contribution.ts
+++ b/src/sql/workbench/contrib/zonecog/browser/zonecogActions.contribution.ts
@@ -1407,6 +1407,153 @@ class ZoneCogAphroditeCompleteAction extends Action2 {
 	}
 }
 
+/**
+ * Action to load a LoRA adapter into the Aphrodite engine
+ */
+class ZoneCogAphroditeLoadAdapterAction extends Action2 {
+
+	static ID = 'zonecog.aphrodite.loadAdapter';
+	constructor() {
+		super({
+			id: ZoneCogAphroditeLoadAdapterAction.ID,
+			title: { value: localize('zonecog.aphroditeLoadAdapter', 'Load LoRA Adapter'), original: 'Load LoRA Adapter' },
+			category: ZONECOG_CATEGORY,
+			icon: Codicon.package_,
+			f1: true,
+			menu: { id: MenuId.CommandPalette },
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const aphroditeService = accessor.get(IAphroditeService);
+		const notificationService = accessor.get(INotificationService);
+		const quickInputService = accessor.get(IQuickInputService);
+
+		if (!aphroditeService.isConnected()) {
+			notificationService.warn(localize('zonecog.aphroditeNotConnectedWarn',
+				'Aphrodite Engine is not connected. Use "Connect to Aphrodite Engine" first.'));
+			return;
+		}
+
+		const adapterId = await quickInputService.input({
+			prompt: localize('zonecog.aphroditeAdapterIdPrompt', 'Enter LoRA adapter ID'),
+			placeHolder: localize('zonecog.aphroditeAdapterIdPlaceholder', 'e.g., my-finetuned-adapter'),
+		});
+
+		if (!adapterId) { return; }
+
+		const adapterPath = await quickInputService.input({
+			prompt: localize('zonecog.aphroditeAdapterPathPrompt', 'Enter LoRA adapter path'),
+			placeHolder: localize('zonecog.aphroditeAdapterPathPlaceholder', 'e.g., /models/adapters/my-finetuned-adapter'),
+		});
+
+		if (!adapterPath) { return; }
+
+		try {
+			const adapter = await aphroditeService.loadAdapter({ id: adapterId, path: adapterPath });
+
+			notificationService.info(localize('zonecog.aphroditeAdapterLoaded',
+				'LoRA adapter loaded: {0} ({1})', adapter.name, adapter.path));
+		} catch (err) {
+			notificationService.error(localize('zonecog.aphroditeLoadAdapterError',
+				'Failed to load LoRA adapter: {0}', err instanceof Error ? err.message : String(err)));
+		}
+	}
+}
+
+/**
+ * Action to swap the active Aphrodite model
+ */
+class ZoneCogAphroditeSwapModelAction extends Action2 {
+
+	static ID = 'zonecog.aphrodite.swapModel';
+	constructor() {
+		super({
+			id: ZoneCogAphroditeSwapModelAction.ID,
+			title: { value: localize('zonecog.aphroditeSwapModel', 'Swap Active Model'), original: 'Swap Active Model' },
+			category: ZONECOG_CATEGORY,
+			icon: Codicon.arrowSwap,
+			f1: true,
+			menu: { id: MenuId.CommandPalette },
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const aphroditeService = accessor.get(IAphroditeService);
+		const notificationService = accessor.get(INotificationService);
+		const quickInputService = accessor.get(IQuickInputService);
+
+		let modelId: string | undefined;
+
+		if (aphroditeService.isConnected()) {
+			try {
+				const models = await aphroditeService.listModels();
+				if (models.length > 0) {
+					const picked = await quickInputService.pick(
+						models.map(m => ({ label: m.id, description: m.loaded ? localize('zonecog.aphroditeModelLoaded', 'loaded') : undefined })),
+						{ placeHolder: localize('zonecog.aphroditeSelectModel', 'Select a model to switch to') }
+					);
+					modelId = picked?.label;
+				}
+			} catch {
+				// Fall through to manual input below when listing models fails.
+			}
+		}
+
+		if (!modelId) {
+			modelId = await quickInputService.input({
+				prompt: localize('zonecog.aphroditeModelIdPrompt', 'Enter model ID to switch to'),
+				placeHolder: localize('zonecog.aphroditeModelIdPlaceholder', 'e.g., llama-3.1-70b'),
+			});
+		}
+
+		if (!modelId) { return; }
+
+		try {
+			await aphroditeService.switchModel(modelId);
+			notificationService.info(localize('zonecog.aphroditeModelSwapped',
+				'Active Aphrodite model switched to: {0}', modelId));
+		} catch (err) {
+			notificationService.error(localize('zonecog.aphroditeSwapModelError',
+				'Failed to switch model: {0}', err instanceof Error ? err.message : String(err)));
+		}
+	}
+}
+
+/**
+ * Action to view Aphrodite request telemetry
+ */
+class ZoneCogAphroditePerformanceAction extends Action2 {
+
+	static ID = 'zonecog.aphrodite.showPerformance';
+	constructor() {
+		super({
+			id: ZoneCogAphroditePerformanceAction.ID,
+			title: { value: localize('zonecog.aphroditePerformance', 'Show Aphrodite Performance Telemetry'), original: 'Show Aphrodite Performance Telemetry' },
+			category: ZONECOG_CATEGORY,
+			icon: Codicon.pulse,
+			f1: true,
+			menu: { id: MenuId.CommandPalette },
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const aphroditeService = accessor.get(IAphroditeService);
+		const notificationService = accessor.get(INotificationService);
+
+		const telemetry = aphroditeService.getTelemetry();
+
+		notificationService.info(localize('zonecog.aphroditePerformanceInfo',
+			'Aphrodite Performance Telemetry:\nRequests: {0}\nErrors: {1}\nAvg Latency: {2}ms\nTokens/sec: {3}\nError Rate: {4}%',
+			telemetry.requestCount,
+			telemetry.errorCount,
+			telemetry.averageLatencyMs.toFixed(1),
+			telemetry.tokensPerSecond.toFixed(2),
+			(telemetry.errorRate * 100).toFixed(1)
+		));
+	}
+}
+
 // =============================================================================
 // Phase 6 actions - Cognitive Workflow Automation
 // =============================================================================
@@ -1619,6 +1766,9 @@ registerAction2(ZoneCogRegisterSchemaInHypergraphAction);
 registerAction2(ZoneCogAphroditeConnectAction);
 registerAction2(ZoneCogAphroditeStatusAction);
 registerAction2(ZoneCogAphroditeCompleteAction);
+registerAction2(ZoneCogAphroditeLoadAdapterAction);
+registerAction2(ZoneCogAphroditeSwapModelAction);
+registerAction2(ZoneCogAphroditePerformanceAction);
 
 // Phase 6 actions
 registerAction2(ZoneCogListWorkflowsAction);

--- a/src/sql/workbench/services/zonecog/browser/aphroditeService.ts
+++ b/src/sql/workbench/services/zonecog/browser/aphroditeService.ts
@@ -186,6 +186,12 @@ export class AphroditeService extends Disposable implements IAphroditeService {
 					success: false,
 					timestamp: Date.now(),
 				});
+				// A caller-initiated cancellation (cancelRequest/cancelAllRequests)
+				// should stop the request outright, not fall through to the next
+				// fallback model.
+				if (error instanceof Error && error.name === 'AbortError') {
+					throw error;
+				}
 				lastError = error;
 			}
 		}
@@ -201,12 +207,15 @@ export class AphroditeService extends Disposable implements IAphroditeService {
 		this._pendingRequests.set(requestId, abortController);
 
 		const startTime = Date.now();
-		const model = this._config.model;
+		// A loaded LoRA adapter is applied by sending its ID as the `model`
+		// field, matching the priority used by complete()'s fallback chain.
+		const model = this._activeAdapterId ?? this._config.model;
 		let completionTokens = 0;
 		let success = false;
 
 		try {
 			const body: Record<string, unknown> = {
+				model,
 				prompt: request.prompt,
 				max_tokens: request.maxTokens ?? this._config.maxTokens,
 				temperature: request.temperature ?? this._config.temperature,
@@ -440,7 +449,10 @@ export class AphroditeService extends Disposable implements IAphroditeService {
 	async loadAdapter(adapter: { id: string; path: string; name?: string; baseModel?: string }): Promise<AphroditeAdapterInfo> {
 		this.membraneService.recordActivity('cerebral');
 
-		await this._makeRequest('/v1/lora_adapters', {
+		// vLLM-compatible dynamic LoRA endpoint (Aphrodite implements the same
+		// OpenAI-compatible server surface); NOT `/v1/lora_adapters`, which
+		// does not exist on either engine.
+		await this._makeRequest('/v1/load_lora_adapter', {
 			lora_name: adapter.id,
 			lora_path: adapter.path,
 		});
@@ -460,7 +472,7 @@ export class AphroditeService extends Disposable implements IAphroditeService {
 
 	async unloadAdapter(adapterId: string): Promise<void> {
 		try {
-			await this._makeRequest(`/v1/lora_adapters/${encodeURIComponent(adapterId)}`, undefined, undefined, 'DELETE');
+			await this._makeRequest('/v1/unload_lora_adapter', { lora_name: adapterId });
 		} catch (error) {
 			// Unloading is a local-state operation first; log but do not
 			// propagate a failed best-effort network call.
@@ -504,7 +516,15 @@ export class AphroditeService extends Disposable implements IAphroditeService {
 	}
 
 	private _buildModelAttemptList(): string[] {
-		const raw = [this._config.model, ...(this._config.fallbackModels ?? [])];
+		// A loaded LoRA adapter is applied by sending its ID as the `model`
+		// field, so an active adapter takes priority over the base model,
+		// falling back to the base model (and its own fallback chain) if the
+		// adapter-routed request fails.
+		const raw = [
+			...(this._activeAdapterId ? [this._activeAdapterId] : []),
+			this._config.model,
+			...(this._config.fallbackModels ?? []),
+		];
 		const models: string[] = [];
 		for (const model of raw) {
 			if (models.length === 0 || models[models.length - 1] !== model) {

--- a/src/sql/workbench/services/zonecog/browser/aphroditeService.ts
+++ b/src/sql/workbench/services/zonecog/browser/aphroditeService.ts
@@ -19,6 +19,9 @@ import {
 	AphroditeEmbeddingResponse,
 	AphroditeModelInfo,
 	AphroditeEngineStats,
+	AphroditeAdapterInfo,
+	AphroditeRequestTelemetry,
+	AphroditeTelemetrySummary,
 } from 'sql/workbench/services/zonecog/common/aphrodite';
 import { ICognitiveMembraneService } from 'sql/workbench/services/zonecog/common/zonecogService';
 
@@ -38,6 +41,8 @@ const DEFAULT_CONFIG: AphroditeConfig = {
 	timeoutMs: 60000,
 	batchingEnabled: true,
 	maxBatchSize: 16,
+	fallbackModels: [],
+	maxTelemetrySamples: 200,
 };
 
 /**
@@ -52,6 +57,11 @@ export class AphroditeService extends Disposable implements IAphroditeService {
 	private _pendingRequests: Map<string, AbortController> = new Map();
 	private _requestIdCounter: number = 0;
 
+	private readonly _adapters: Map<string, AphroditeAdapterInfo> = new Map();
+	private _activeAdapterId: string | undefined;
+
+	private readonly _telemetry: AphroditeRequestTelemetry[] = [];
+
 	private readonly _onDidReceiveStreamToken = this._register(new Emitter<AphroditeStreamToken>());
 	readonly onDidReceiveStreamToken: Event<AphroditeStreamToken> = this._onDidReceiveStreamToken.event;
 
@@ -60,6 +70,9 @@ export class AphroditeService extends Disposable implements IAphroditeService {
 
 	private readonly _onDidUpdateStats = this._register(new Emitter<AphroditeEngineStats>());
 	readonly onDidUpdateStats: Event<AphroditeEngineStats> = this._onDidUpdateStats.event;
+
+	private readonly _onDidUpdateTelemetry = this._register(new Emitter<AphroditeTelemetrySummary>());
+	readonly onDidUpdateTelemetry: Event<AphroditeTelemetrySummary> = this._onDidUpdateTelemetry.event;
 
 	constructor(
 		@ILogService private readonly logService: ILogService,
@@ -108,54 +121,20 @@ export class AphroditeService extends Disposable implements IAphroditeService {
 
 	async complete(request: AphroditeCompletionRequest): Promise<AphroditeCompletionResponse> {
 		this.membraneService.recordActivity('cerebral');
-		const requestId = request.requestId ?? this._generateRequestId();
-		const abortController = new AbortController();
-		this._pendingRequests.set(requestId, abortController);
 
-		const startTime = Date.now();
+		const modelsToTry = this._buildModelAttemptList();
+		let lastError: unknown;
 
-		try {
-			const response = await this._makeRequest('/v1/completions', {
-				prompt: request.prompt,
-				max_tokens: request.maxTokens ?? this._config.maxTokens,
-				temperature: request.temperature ?? this._config.temperature,
-				top_p: this._config.topP,
-				top_k: this._config.topK,
-				frequency_penalty: this._config.frequencyPenalty,
-				presence_penalty: this._config.presencePenalty,
-				stop: request.stopSequences,
-				stream: false,
-			}, abortController.signal);
+		for (const model of modelsToTry) {
+			const requestId = request.requestId ?? this._generateRequestId();
+			const abortController = new AbortController();
+			this._pendingRequests.set(requestId, abortController);
 
-			const generationTimeMs = Date.now() - startTime;
-			this._pendingRequests.delete(requestId);
+			const startTime = Date.now();
 
-			return {
-				text: response.choices[0]?.text ?? '',
-				promptTokens: response.usage?.prompt_tokens ?? 0,
-				completionTokens: response.usage?.completion_tokens ?? 0,
-				totalTokens: response.usage?.total_tokens ?? 0,
-				finishReason: response.choices[0]?.finish_reason ?? 'stop',
-				generationTimeMs,
-				model: response.model ?? this._config.model,
-			};
-		} catch (error) {
-			this._pendingRequests.delete(requestId);
-			throw error;
-		}
-	}
-
-	async *streamComplete(request: AphroditeCompletionRequest): AsyncIterable<AphroditeStreamToken> {
-		this.membraneService.recordActivity('cerebral');
-		const requestId = request.requestId ?? this._generateRequestId();
-		const abortController = new AbortController();
-		this._pendingRequests.set(requestId, abortController);
-
-		try {
-			const response = await fetch(`${this._config.baseUrl}/v1/completions`, {
-				method: 'POST',
-				headers: this._getHeaders(),
-				body: JSON.stringify({
+			try {
+				const body: Record<string, unknown> = {
+					model,
 					prompt: request.prompt,
 					max_tokens: request.maxTokens ?? this._config.maxTokens,
 					temperature: request.temperature ?? this._config.temperature,
@@ -164,8 +143,88 @@ export class AphroditeService extends Disposable implements IAphroditeService {
 					frequency_penalty: this._config.frequencyPenalty,
 					presence_penalty: this._config.presencePenalty,
 					stop: request.stopSequences,
-					stream: true,
-				}),
+					stream: false,
+				};
+				if (request.responseFormat?.type === 'json_schema') {
+					body['guided_json'] = request.responseFormat.schema;
+				}
+
+				const response = await this._makeRequest('/v1/completions', body, abortController.signal);
+
+				const generationTimeMs = Date.now() - startTime;
+				this._pendingRequests.delete(requestId);
+
+				const completionResponse: AphroditeCompletionResponse = {
+					text: response.choices[0]?.text ?? '',
+					promptTokens: response.usage?.prompt_tokens ?? 0,
+					completionTokens: response.usage?.completion_tokens ?? 0,
+					totalTokens: response.usage?.total_tokens ?? 0,
+					finishReason: response.choices[0]?.finish_reason ?? 'stop',
+					generationTimeMs,
+					model: response.model ?? model,
+				};
+
+				this._recordTelemetry({
+					requestId,
+					model,
+					latencyMs: generationTimeMs,
+					promptTokens: completionResponse.promptTokens,
+					completionTokens: completionResponse.completionTokens,
+					success: true,
+					timestamp: Date.now(),
+				});
+
+				return completionResponse;
+			} catch (error) {
+				this._pendingRequests.delete(requestId);
+				this._recordTelemetry({
+					requestId,
+					model,
+					latencyMs: Date.now() - startTime,
+					promptTokens: 0,
+					completionTokens: 0,
+					success: false,
+					timestamp: Date.now(),
+				});
+				lastError = error;
+			}
+		}
+
+		const lastErrorMessage = lastError instanceof Error ? lastError.message : String(lastError);
+		throw new Error(`Aphrodite completion failed for model(s) [${modelsToTry.join(', ')}]: ${lastErrorMessage}`);
+	}
+
+	async *streamComplete(request: AphroditeCompletionRequest): AsyncIterable<AphroditeStreamToken> {
+		this.membraneService.recordActivity('cerebral');
+		const requestId = request.requestId ?? this._generateRequestId();
+		const abortController = new AbortController();
+		this._pendingRequests.set(requestId, abortController);
+
+		const startTime = Date.now();
+		const model = this._config.model;
+		let completionTokens = 0;
+		let success = false;
+
+		try {
+			const body: Record<string, unknown> = {
+				prompt: request.prompt,
+				max_tokens: request.maxTokens ?? this._config.maxTokens,
+				temperature: request.temperature ?? this._config.temperature,
+				top_p: this._config.topP,
+				top_k: this._config.topK,
+				frequency_penalty: this._config.frequencyPenalty,
+				presence_penalty: this._config.presencePenalty,
+				stop: request.stopSequences,
+				stream: true,
+			};
+			if (request.responseFormat?.type === 'json_schema') {
+				body['guided_json'] = request.responseFormat.schema;
+			}
+
+			const response = await fetch(`${this._config.baseUrl}/v1/completions`, {
+				method: 'POST',
+				headers: this._getHeaders(),
+				body: JSON.stringify(body),
 				signal: abortController.signal,
 			});
 
@@ -201,6 +260,7 @@ export class AphroditeService extends Disposable implements IAphroditeService {
 								finishReason: 'stop',
 							};
 							this._onDidReceiveStreamToken.fire(token);
+							success = true;
 							yield token;
 							return;
 						}
@@ -216,6 +276,7 @@ export class AphroditeService extends Disposable implements IAphroditeService {
 									finished: choice.finish_reason !== null,
 									finishReason: choice.finish_reason,
 								};
+								completionTokens++;
 								this._onDidReceiveStreamToken.fire(token);
 								yield token;
 							}
@@ -225,8 +286,18 @@ export class AphroditeService extends Disposable implements IAphroditeService {
 					}
 				}
 			}
+			success = true;
 		} finally {
 			this._pendingRequests.delete(requestId);
+			this._recordTelemetry({
+				requestId,
+				model,
+				latencyMs: Date.now() - startTime,
+				promptTokens: 0,
+				completionTokens,
+				success,
+				timestamp: Date.now(),
+			});
 		}
 	}
 
@@ -364,6 +435,92 @@ export class AphroditeService extends Disposable implements IAphroditeService {
 			this._pendingRequests.delete(requestId);
 		}
 		this.logService.info('[AphroditeService] Cancelled all requests');
+	}
+
+	async loadAdapter(adapter: { id: string; path: string; name?: string; baseModel?: string }): Promise<AphroditeAdapterInfo> {
+		this.membraneService.recordActivity('cerebral');
+
+		await this._makeRequest('/v1/lora_adapters', {
+			lora_name: adapter.id,
+			lora_path: adapter.path,
+		});
+
+		const info: AphroditeAdapterInfo = {
+			id: adapter.id,
+			name: adapter.name ?? adapter.id,
+			path: adapter.path,
+			loaded: true,
+			baseModel: adapter.baseModel,
+		};
+		this._adapters.set(adapter.id, info);
+		this._activeAdapterId = adapter.id;
+		this.logService.info(`[AphroditeService] Loaded adapter: ${adapter.id}`);
+		return info;
+	}
+
+	async unloadAdapter(adapterId: string): Promise<void> {
+		try {
+			await this._makeRequest(`/v1/lora_adapters/${encodeURIComponent(adapterId)}`, undefined, undefined, 'DELETE');
+		} catch (error) {
+			// Unloading is a local-state operation first; log but do not
+			// propagate a failed best-effort network call.
+			this.logService.warn(`[AphroditeService] Failed to unload adapter '${adapterId}' on the engine: ${error instanceof Error ? error.message : String(error)}`);
+		} finally {
+			this._adapters.delete(adapterId);
+			if (this._activeAdapterId === adapterId) {
+				this._activeAdapterId = undefined;
+			}
+		}
+	}
+
+	async listAdapters(): Promise<AphroditeAdapterInfo[]> {
+		return Array.from(this._adapters.values());
+	}
+
+	getActiveAdapter(): AphroditeAdapterInfo | undefined {
+		return this._activeAdapterId ? this._adapters.get(this._activeAdapterId) : undefined;
+	}
+
+	getTelemetry(): AphroditeTelemetrySummary {
+		const samples = this._telemetry;
+		const requestCount = samples.length;
+		const errorCount = samples.filter(s => !s.success).length;
+		const averageLatencyMs = requestCount > 0
+			? samples.reduce((sum, s) => sum + s.latencyMs, 0) / requestCount
+			: 0;
+
+		const successfulSamples = samples.filter(s => s.success);
+		const totalCompletionTokens = successfulSamples.reduce((sum, s) => sum + s.completionTokens, 0);
+		const totalSuccessLatencySeconds = successfulSamples.reduce((sum, s) => sum + s.latencyMs, 0) / 1000;
+		const tokensPerSecond = totalSuccessLatencySeconds > 0 ? totalCompletionTokens / totalSuccessLatencySeconds : 0;
+
+		const errorRate = requestCount > 0 ? errorCount / requestCount : 0;
+
+		return { requestCount, errorCount, averageLatencyMs, tokensPerSecond, errorRate };
+	}
+
+	getTelemetrySamples(): AphroditeRequestTelemetry[] {
+		return [...this._telemetry];
+	}
+
+	private _buildModelAttemptList(): string[] {
+		const raw = [this._config.model, ...(this._config.fallbackModels ?? [])];
+		const models: string[] = [];
+		for (const model of raw) {
+			if (models.length === 0 || models[models.length - 1] !== model) {
+				models.push(model);
+			}
+		}
+		return models;
+	}
+
+	private _recordTelemetry(sample: AphroditeRequestTelemetry): void {
+		this._telemetry.push(sample);
+		const maxSamples = this._config.maxTelemetrySamples ?? 200;
+		while (this._telemetry.length > maxSamples) {
+			this._telemetry.shift();
+		}
+		this._onDidUpdateTelemetry.fire(this.getTelemetry());
 	}
 
 	private _generateRequestId(): string {

--- a/src/sql/workbench/services/zonecog/browser/hypergraphSemanticSearchService.ts
+++ b/src/sql/workbench/services/zonecog/browser/hypergraphSemanticSearchService.ts
@@ -242,11 +242,20 @@ export class HypergraphSemanticSearchService extends Disposable implements IHype
 		this.membraneService.recordActivity('cerebral');
 		const vectors = await this._embedBatch(pending.map(p => nodeEmbeddingText(p.node)));
 
+		// Insert every entry from this batch before evicting, and never evict
+		// one of them to make room for another: otherwise a batch larger than
+		// the tail of the index could evict entries it just computed, so the
+		// caller (search()) would silently miss candidates it just paid to
+		// embed. The index may temporarily exceed MAX_INDEX_SIZE if the batch
+		// itself is larger than the cap.
+		const pendingIds = new Set(pending.map(p => p.node.id));
 		for (let i = 0; i < pending.length; i++) {
 			const { node, contentHash } = pending[i];
-			this._setIndexEntry(node.id, { vector: vectors[i], contentHash, source });
+			this._index.delete(node.id);
+			this._index.set(node.id, { vector: vectors[i], contentHash, source });
 			this._onDidIndexNode.fire(node.id);
 		}
+		this._evictIfNeeded(pendingIds);
 
 		return pending.length;
 	}
@@ -322,14 +331,32 @@ export class HypergraphSemanticSearchService extends Disposable implements IHype
 	}
 
 	/**
-	 * Sets an index entry (marking it most-recently-used) and evicts the
-	 * least-recently-used entries if the index would exceed `MAX_INDEX_SIZE`.
+	 * Sets an index entry (marking it most-recently-used) and evicts
+	 * least-recently-used entries if the index would exceed `MAX_INDEX_SIZE`,
+	 * protecting `nodeId` itself from that eviction pass.
 	 */
 	private _setIndexEntry(nodeId: string, entry: IndexEntry): void {
 		this._index.delete(nodeId);
 		this._index.set(nodeId, entry);
+		this._evictIfNeeded(new Set([nodeId]));
+	}
+
+	/**
+	 * Evicts least-recently-used entries down to `MAX_INDEX_SIZE`, never
+	 * evicting an entry whose ID is in `protectedIds` (the entries the
+	 * current caller just wrote and is about to read back). If every
+	 * remaining entry is protected, the index is left over the cap rather
+	 * than dropping data the caller just paid to compute.
+	 */
+	private _evictIfNeeded(protectedIds: ReadonlySet<string>): void {
 		while (this._index.size > MAX_INDEX_SIZE) {
-			const oldestKey = this._index.keys().next().value;
+			let oldestKey: string | undefined;
+			for (const key of this._index.keys()) {
+				if (!protectedIds.has(key)) {
+					oldestKey = key;
+					break;
+				}
+			}
 			if (oldestKey === undefined) {
 				break;
 			}

--- a/src/sql/workbench/services/zonecog/browser/hypergraphSemanticSearchService.ts
+++ b/src/sql/workbench/services/zonecog/browser/hypergraphSemanticSearchService.ts
@@ -17,6 +17,12 @@ import { IHypergraphStore, HypergraphNode, ICognitiveMembraneService } from 'sql
 /** Dimensionality of the deterministic local fallback embedding. */
 const LOCAL_EMBEDDING_DIM = 128;
 
+/** Maximum number of entries retained in the in-memory embedding index (LRU-evicted beyond this). */
+const MAX_INDEX_SIZE = 5000;
+
+/** Fallback batch size used when the Aphrodite service's configured `maxBatchSize` is unavailable. */
+const DEFAULT_EMBED_BATCH_SIZE = 16;
+
 interface IndexEntry {
 	vector: number[];
 	contentHash: string;
@@ -142,14 +148,7 @@ export class HypergraphSemanticSearchService extends Disposable implements IHype
 			? nodeTypes.flatMap(type => this.hypergraphStore.getNodesByType(type))
 			: this.hypergraphStore.getAllNodes();
 
-		let indexed = 0;
-		for (const node of nodes) {
-			const before = this._index.get(node.id);
-			await this._ensureIndexed(node);
-			if (!before || before !== this._index.get(node.id)) {
-				indexed++;
-			}
-		}
+		const indexed = await this._ensureIndexedBatch(nodes);
 		this.logService.info(`HypergraphSemanticSearchService: indexed ${indexed}/${nodes.length} node(s)`);
 		return indexed;
 	}
@@ -167,14 +166,12 @@ export class HypergraphSemanticSearchService extends Disposable implements IHype
 			return [];
 		}
 
-		for (const node of candidates) {
-			await this._ensureIndexed(node);
-		}
+		await this._ensureIndexedBatch(candidates);
 
 		const queryVector = await this._embed(query);
 		const results: SemanticSearchResult[] = [];
 		for (const node of candidates) {
-			const entry = this._index.get(node.id);
+			const entry = this._touch(node.id);
 			if (!entry) {
 				continue;
 			}
@@ -208,15 +205,50 @@ export class HypergraphSemanticSearchService extends Disposable implements IHype
 	private async _ensureIndexed(node: HypergraphNode): Promise<void> {
 		const contentHash = this._contentHash(node);
 		const source = this._currentSource();
-		const existing = this._index.get(node.id);
+		const existing = this._touch(node.id);
 		if (existing && existing.contentHash === contentHash && existing.source === source) {
 			return;
 		}
 
 		this.membraneService.recordActivity('cerebral');
 		const vector = await this._embed(nodeEmbeddingText(node));
-		this._index.set(node.id, { vector, contentHash, source });
+		this._setIndexEntry(node.id, { vector, contentHash, source });
 		this._onDidIndexNode.fire(node.id);
+	}
+
+	/**
+	 * Ensures every node in `nodes` has an up-to-date index entry, batching
+	 * the underlying `embed()` calls to Aphrodite when connected so that N
+	 * uncached nodes cost `ceil(N / maxBatchSize)` requests instead of N.
+	 * Returns the number of nodes that were (re-)indexed.
+	 */
+	private async _ensureIndexedBatch(nodes: HypergraphNode[]): Promise<number> {
+		const source = this._currentSource();
+		const pending: { node: HypergraphNode; contentHash: string }[] = [];
+
+		for (const node of nodes) {
+			const contentHash = this._contentHash(node);
+			const existing = this._touch(node.id);
+			if (existing && existing.contentHash === contentHash && existing.source === source) {
+				continue;
+			}
+			pending.push({ node, contentHash });
+		}
+
+		if (pending.length === 0) {
+			return 0;
+		}
+
+		this.membraneService.recordActivity('cerebral');
+		const vectors = await this._embedBatch(pending.map(p => nodeEmbeddingText(p.node)));
+
+		for (let i = 0; i < pending.length; i++) {
+			const { node, contentHash } = pending[i];
+			this._setIndexEntry(node.id, { vector: vectors[i], contentHash, source });
+			this._onDidIndexNode.fire(node.id);
+		}
+
+		return pending.length;
 	}
 
 	private _currentSource(): SemanticEmbeddingSource {
@@ -236,6 +268,73 @@ export class HypergraphSemanticSearchService extends Disposable implements IHype
 			}
 		}
 		return localEmbed(text);
+	}
+
+	/**
+	 * Embeds a batch of texts, chunking calls to `aphroditeService.embed()`
+	 * by its configured `maxBatchSize` when connected. Falls back to the
+	 * local hashing-trick embedding per-text when not connected, or per-item
+	 * within a chunk if the Aphrodite call for that chunk fails.
+	 */
+	private async _embedBatch(texts: string[]): Promise<number[][]> {
+		if (texts.length === 0) {
+			return [];
+		}
+
+		if (!this.aphroditeService.isConnected()) {
+			return texts.map(text => localEmbed(text));
+		}
+
+		const batchSize = this.aphroditeService.getConfig().maxBatchSize || DEFAULT_EMBED_BATCH_SIZE;
+		const results: number[][] = new Array(texts.length);
+
+		for (let start = 0; start < texts.length; start += batchSize) {
+			const chunk = texts.slice(start, start + batchSize);
+			try {
+				const response = await this.aphroditeService.embed({ texts: chunk });
+				for (let i = 0; i < chunk.length; i++) {
+					const vector = response.embeddings[i];
+					results[start + i] = vector && vector.length > 0 ? vector : localEmbed(chunk[i]);
+				}
+			} catch (err) {
+				this.logService.warn(`HypergraphSemanticSearchService: Aphrodite embed() failed for batch, falling back to local embedding: ${err instanceof Error ? err.message : String(err)}`);
+				for (let i = 0; i < chunk.length; i++) {
+					results[start + i] = localEmbed(chunk[i]);
+				}
+			}
+		}
+
+		return results;
+	}
+
+	/**
+	 * Reinserts a key at the end of `_index` (Map preserves insertion order)
+	 * so the first key is always the least-recently-used entry, and returns
+	 * the entry if present. Used to mark both reads and writes as "recent".
+	 */
+	private _touch(nodeId: string): IndexEntry | undefined {
+		const entry = this._index.get(nodeId);
+		if (entry) {
+			this._index.delete(nodeId);
+			this._index.set(nodeId, entry);
+		}
+		return entry;
+	}
+
+	/**
+	 * Sets an index entry (marking it most-recently-used) and evicts the
+	 * least-recently-used entries if the index would exceed `MAX_INDEX_SIZE`.
+	 */
+	private _setIndexEntry(nodeId: string, entry: IndexEntry): void {
+		this._index.delete(nodeId);
+		this._index.set(nodeId, entry);
+		while (this._index.size > MAX_INDEX_SIZE) {
+			const oldestKey = this._index.keys().next().value;
+			if (oldestKey === undefined) {
+				break;
+			}
+			this._index.delete(oldestKey);
+		}
 	}
 
 	private _contentHash(node: HypergraphNode): string {

--- a/src/sql/workbench/services/zonecog/common/aphrodite.ts
+++ b/src/sql/workbench/services/zonecog/common/aphrodite.ts
@@ -34,6 +34,10 @@ export interface AphroditeConfig {
 	batchingEnabled: boolean;
 	/** Max batch size */
 	maxBatchSize: number;
+	/** Models to try in order if the primary model's completion request fails */
+	fallbackModels?: string[];
+	/** Max number of request telemetry samples retained in memory (ring buffer) */
+	maxTelemetrySamples?: number;
 }
 
 /**
@@ -72,6 +76,12 @@ export interface AphroditeCompletionRequest {
 	priority?: number;
 	/** Request ID for tracking */
 	requestId?: string;
+	/** Structured output format; passed through as `guided_json` when set */
+	responseFormat?: {
+		type: 'json_schema';
+		/** JSON schema the completion must conform to */
+		schema: Record<string, unknown>;
+	};
 }
 
 /**
@@ -182,6 +192,58 @@ export interface AphroditeEngineStats {
 	kvCacheSize: number;
 }
 
+/**
+ * Information about a loaded (or loadable) LoRA adapter.
+ */
+export interface AphroditeAdapterInfo {
+	/** Adapter ID (also used as its `lora_name`) */
+	id: string;
+	/** Human-readable name */
+	name: string;
+	/** Path the adapter was loaded from */
+	path: string;
+	/** Whether the adapter is currently loaded */
+	loaded: boolean;
+	/** Base model the adapter was trained against, if known */
+	baseModel?: string;
+}
+
+/**
+ * A single request's telemetry sample.
+ */
+export interface AphroditeRequestTelemetry {
+	/** Request ID this sample corresponds to */
+	requestId: string;
+	/** Model used for the request */
+	model: string;
+	/** End-to-end latency in milliseconds */
+	latencyMs: number;
+	/** Number of prompt tokens */
+	promptTokens: number;
+	/** Number of completion tokens */
+	completionTokens: number;
+	/** Whether the request succeeded */
+	success: boolean;
+	/** Epoch milliseconds when the sample was recorded */
+	timestamp: number;
+}
+
+/**
+ * Aggregate telemetry summary computed from recorded request samples.
+ */
+export interface AphroditeTelemetrySummary {
+	/** Total number of recorded requests */
+	requestCount: number;
+	/** Number of requests that failed */
+	errorCount: number;
+	/** Mean latency across all recorded requests, in milliseconds */
+	averageLatencyMs: number;
+	/** Aggregate completion tokens per second across successful requests */
+	tokensPerSecond: number;
+	/** Fraction of recorded requests that failed (0-1) */
+	errorRate: number;
+}
+
 export const IAphroditeService = createDecorator<IAphroditeService>('aphroditeService');
 
 /**
@@ -205,6 +267,11 @@ export interface IAphroditeService {
 	 * Event fired when engine stats update.
 	 */
 	readonly onDidUpdateStats: Event<AphroditeEngineStats>;
+
+	/**
+	 * Event fired when request telemetry updates.
+	 */
+	readonly onDidUpdateTelemetry: Event<AphroditeTelemetrySummary>;
 
 	/**
 	 * Initialize the service and connect to Aphrodite.
@@ -282,4 +349,36 @@ export interface IAphroditeService {
 	 * Cancel all pending requests.
 	 */
 	cancelAllRequests(): void;
+
+	/**
+	 * Load a LoRA adapter into the engine.
+	 */
+	loadAdapter(adapter: { id: string; path: string; name?: string; baseModel?: string }): Promise<AphroditeAdapterInfo>;
+
+	/**
+	 * Unload a previously loaded LoRA adapter.
+	 */
+	unloadAdapter(adapterId: string): Promise<void>;
+
+	/**
+	 * List locally tracked LoRA adapters. Resolves synchronously against local
+	 * state (there is no dedicated list endpoint) but returns a Promise for
+	 * API consistency with the other adapter-management methods.
+	 */
+	listAdapters(): Promise<AphroditeAdapterInfo[]>;
+
+	/**
+	 * Get the currently active LoRA adapter, if any.
+	 */
+	getActiveAdapter(): AphroditeAdapterInfo | undefined;
+
+	/**
+	 * Get the aggregate request telemetry summary.
+	 */
+	getTelemetry(): AphroditeTelemetrySummary;
+
+	/**
+	 * Get a copy of the recorded per-request telemetry samples.
+	 */
+	getTelemetrySamples(): AphroditeRequestTelemetry[];
 }

--- a/src/sql/workbench/services/zonecog/test/browser/aphroditeService.test.ts
+++ b/src/sql/workbench/services/zonecog/test/browser/aphroditeService.test.ts
@@ -222,4 +222,129 @@ suite('AphroditeService', () => {
 		assert.strictEqual(typeof config.maxBatchSize, 'number');
 		assert.ok(config.maxBatchSize > 0);
 	});
+
+	// --- Adapters ---
+
+	test('should start with no active adapter', () => {
+		assert.strictEqual(aphroditeService.getActiveAdapter(), undefined);
+	});
+
+	test('listAdapters should start empty', async () => {
+		const adapters = await aphroditeService.listAdapters();
+		assert.deepStrictEqual(adapters, []);
+	});
+
+	test('loadAdapter should throw when server unavailable', async () => {
+		try {
+			await aphroditeService.loadAdapter({ id: 'my-adapter', path: '/models/adapters/my-adapter' });
+			assert.fail('Should have thrown');
+		} catch (error) {
+			assert.ok(error);
+		}
+
+		// A failed load should not register the adapter locally.
+		assert.strictEqual(aphroditeService.getActiveAdapter(), undefined);
+		assert.deepStrictEqual(await aphroditeService.listAdapters(), []);
+	});
+
+	test('unloadAdapter should clear local state even when the network call fails', async () => {
+		// Should not throw even though there is no server and nothing was loaded.
+		await aphroditeService.unloadAdapter('non-existent-adapter');
+		assert.strictEqual(aphroditeService.getActiveAdapter(), undefined);
+	});
+
+	// --- Telemetry ---
+
+	test('should start with zeroed telemetry', () => {
+		const telemetry = aphroditeService.getTelemetry();
+		assert.strictEqual(telemetry.requestCount, 0);
+		assert.strictEqual(telemetry.errorCount, 0);
+		assert.strictEqual(telemetry.averageLatencyMs, 0);
+		assert.strictEqual(telemetry.tokensPerSecond, 0);
+		assert.strictEqual(telemetry.errorRate, 0);
+		assert.deepStrictEqual(aphroditeService.getTelemetrySamples(), []);
+	});
+
+	test('should have onDidUpdateTelemetry event', () => {
+		assert.ok(aphroditeService.onDidUpdateTelemetry);
+
+		const disposable = aphroditeService.onDidUpdateTelemetry(() => { });
+
+		disposable.dispose();
+	});
+
+	test('complete should record a telemetry sample and fire onDidUpdateTelemetry on failure', async () => {
+		let fired: ReturnType<typeof aphroditeService.getTelemetry> | undefined;
+		aphroditeService.onDidUpdateTelemetry(summary => fired = summary);
+
+		try {
+			await aphroditeService.complete({ prompt: 'Hello, world!' });
+		} catch {
+			// Expected: no server available.
+		}
+
+		const telemetry = aphroditeService.getTelemetry();
+		assert.strictEqual(telemetry.requestCount, 1);
+		assert.strictEqual(telemetry.errorCount, 1);
+		assert.strictEqual(telemetry.errorRate, 1);
+		assert.ok(fired);
+		assert.strictEqual(fired!.requestCount, 1);
+
+		const samples = aphroditeService.getTelemetrySamples();
+		assert.strictEqual(samples.length, 1);
+		assert.strictEqual(samples[0].success, false);
+		assert.strictEqual(samples[0].model, 'default');
+	});
+
+	test('complete should try each fallback model and throw an error mentioning all attempted models', async () => {
+		aphroditeService.updateConfig({ model: 'primary-model', fallbackModels: ['fallback-a', 'fallback-b'] });
+
+		try {
+			await aphroditeService.complete({ prompt: 'Hello, world!' });
+			assert.fail('Should have thrown');
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			assert.ok(message.includes('primary-model'));
+			assert.ok(message.includes('fallback-a'));
+			assert.ok(message.includes('fallback-b'));
+		}
+
+		// One telemetry sample should have been recorded per attempted model.
+		const samples = aphroditeService.getTelemetrySamples();
+		assert.strictEqual(samples.length, 3);
+		assert.deepStrictEqual(samples.map(s => s.model), ['primary-model', 'fallback-a', 'fallback-b']);
+		assert.ok(samples.every(s => s.success === false));
+
+		const telemetry = aphroditeService.getTelemetry();
+		assert.strictEqual(telemetry.requestCount, 3);
+		assert.strictEqual(telemetry.errorCount, 3);
+	});
+
+	test('embed should not record completion telemetry', async () => {
+		try {
+			await aphroditeService.complete({ prompt: 'first' });
+		} catch { /* expected: offline */ }
+		try {
+			await aphroditeService.embed({ texts: ['second'] });
+		} catch { /* expected: offline, embed does not record telemetry */ }
+
+		// Only the complete() call above should have produced a sample.
+		const telemetry = aphroditeService.getTelemetry();
+		assert.strictEqual(telemetry.requestCount, 1);
+		assert.strictEqual(telemetry.errorCount, 1);
+	});
+
+	test('streamComplete should record a telemetry sample on failure', async () => {
+		try {
+			for await (const _token of aphroditeService.streamComplete({ prompt: 'Hello, world!' })) {
+				// no-op: no server available, so this should never yield
+			}
+		} catch {
+			// Expected: no server available.
+		}
+
+		const telemetry = aphroditeService.getTelemetry();
+		assert.strictEqual(telemetry.requestCount, 1);
+		assert.strictEqual(telemetry.errorCount, 1);
+	});
 });

--- a/src/sql/workbench/services/zonecog/test/browser/aphroditeService.test.ts
+++ b/src/sql/workbench/services/zonecog/test/browser/aphroditeService.test.ts
@@ -347,4 +347,122 @@ suite('AphroditeService', () => {
 		assert.strictEqual(telemetry.requestCount, 1);
 		assert.strictEqual(telemetry.errorCount, 1);
 	});
+
+	// --- Adapter routing, streaming model field, and cancellation ---
+	// (regression coverage for Cursor Bugbot findings on PR #90)
+
+	function withMockFetch<T>(handler: (url: string, options: any) => any, fn: () => Promise<T>): Promise<T> {
+		const original = (globalThis as any).fetch;
+		(globalThis as any).fetch = async (url: string, options: any) => handler(url, options);
+		return fn().finally(() => {
+			(globalThis as any).fetch = original;
+		});
+	}
+
+	test('loadAdapter should call the vLLM-compatible /v1/load_lora_adapter endpoint', async () => {
+		const calls: { url: string; body: any }[] = [];
+		await withMockFetch(
+			(url, options) => {
+				calls.push({ url, body: JSON.parse(options.body) });
+				return { ok: true, json: async () => ({}) };
+			},
+			() => aphroditeService.loadAdapter({ id: 'my-adapter', path: '/models/my-adapter' })
+		);
+
+		assert.strictEqual(calls.length, 1);
+		assert.ok(calls[0].url.endsWith('/v1/load_lora_adapter'));
+		assert.deepStrictEqual(calls[0].body, { lora_name: 'my-adapter', lora_path: '/models/my-adapter' });
+	});
+
+	test('unloadAdapter should call the vLLM-compatible /v1/unload_lora_adapter endpoint', async () => {
+		const calls: { url: string; body: any }[] = [];
+		await withMockFetch(
+			(url, options) => {
+				calls.push({ url, body: JSON.parse(options.body) });
+				return { ok: true, json: async () => ({}) };
+			},
+			() => aphroditeService.unloadAdapter('my-adapter')
+		);
+
+		assert.strictEqual(calls.length, 1);
+		assert.ok(calls[0].url.endsWith('/v1/unload_lora_adapter'));
+		assert.deepStrictEqual(calls[0].body, { lora_name: 'my-adapter' });
+	});
+
+	test('complete should route through the active adapter as the model field', async () => {
+		await withMockFetch(
+			() => ({ ok: true, json: async () => ({}) }),
+			() => aphroditeService.loadAdapter({ id: 'my-adapter', path: '/models/my-adapter' })
+		);
+		assert.strictEqual(aphroditeService.getActiveAdapter()?.id, 'my-adapter');
+
+		const calls: any[] = [];
+		await withMockFetch(
+			(_url, options) => {
+				calls.push(JSON.parse(options.body));
+				return {
+					ok: true,
+					json: async () => ({ choices: [{ text: 'hi', finish_reason: 'stop' }], usage: {}, model: 'my-adapter' }),
+				};
+			},
+			() => aphroditeService.complete({ prompt: 'hello' })
+		);
+
+		assert.strictEqual(calls.length, 1);
+		assert.strictEqual(calls[0].model, 'my-adapter');
+	});
+
+	test('streamComplete should include the resolved model in the request body', async () => {
+		const calls: any[] = [];
+		try {
+			await withMockFetch(
+				(_url, options) => {
+					calls.push(JSON.parse(options.body));
+					return { ok: false, status: 500 };
+				},
+				async () => {
+					for await (const _token of aphroditeService.streamComplete({ prompt: 'hello' })) {
+						// no-op: the mock returns a non-ok response before any tokens
+					}
+				}
+			);
+		} catch {
+			// Expected: mock fetch returns a non-ok response.
+		}
+
+		assert.strictEqual(calls.length, 1);
+		assert.strictEqual(calls[0].model, 'default');
+	});
+
+	test('complete should stop immediately on cancellation instead of trying fallback models', async () => {
+		aphroditeService.updateConfig({ fallbackModels: ['fallback-a', 'fallback-b'] });
+
+		const requestId = 'cancel-me';
+		const completePromise = withMockFetch(
+			(_url, options) => new Promise((_resolve, reject) => {
+				const signal: AbortSignal | undefined = options?.signal;
+				signal?.addEventListener('abort', () => {
+					const err = new Error('The operation was aborted.');
+					err.name = 'AbortError';
+					reject(err);
+				});
+			}),
+			() => aphroditeService.complete({ prompt: 'hello', requestId })
+		);
+
+		aphroditeService.cancelRequest(requestId);
+
+		try {
+			await completePromise;
+			assert.fail('Should have thrown');
+		} catch (error) {
+			assert.ok(error instanceof Error);
+			assert.strictEqual((error as Error).name, 'AbortError');
+		}
+
+		// Only the cancelled attempt should have been recorded - the fallback
+		// chain must not have been tried after cancellation.
+		const samples = aphroditeService.getTelemetrySamples();
+		assert.strictEqual(samples.length, 1);
+	});
 });

--- a/src/sql/workbench/services/zonecog/test/browser/hypergraphSemanticSearchService.test.ts
+++ b/src/sql/workbench/services/zonecog/test/browser/hypergraphSemanticSearchService.test.ts
@@ -19,6 +19,7 @@ suite('Hypergraph Semantic Search Service Tests', () => {
 	let instantiationService: TestInstantiationService;
 	let searchService: IHypergraphSemanticSearchService;
 	let hypergraphStore: IHypergraphStore;
+	let aphroditeService: AphroditeService;
 
 	setup(() => {
 		instantiationService = new TestInstantiationService();
@@ -30,7 +31,7 @@ suite('Hypergraph Semantic Search Service Tests', () => {
 		const membraneService = instantiationService.createInstance(CognitiveMembraneService);
 		instantiationService.stub(ICognitiveMembraneService, membraneService);
 
-		const aphroditeService = instantiationService.createInstance(AphroditeService);
+		aphroditeService = instantiationService.createInstance(AphroditeService);
 		instantiationService.stub(IAphroditeService, aphroditeService);
 
 		searchService = instantiationService.createInstance(HypergraphSemanticSearchService);
@@ -174,5 +175,102 @@ suite('Hypergraph Semantic Search Service Tests', () => {
 		searchService.clear();
 		assert.strictEqual(searchService.getIndexedCount(), 0);
 		assert.strictEqual(searchService.isIndexed('n1'), false);
+	});
+
+	// --- Batched embedding (connected to Aphrodite) ---
+
+	function stubConnectedAphrodite(): { embedCallCount: () => number } {
+		// Constrained test double: the real AphroditeService is always
+		// offline in tests (no server running), so we override its
+		// isConnected()/embed() to exercise the batched-embedding path.
+		let embedCallCount = 0;
+		(aphroditeService as any).isConnected = () => true;
+		(aphroditeService as any).embed = async (request: { texts: string[] }) => {
+			embedCallCount++;
+			return {
+				embeddings: request.texts.map(() => [1, 0, 0]),
+				dimension: 3,
+				model: 'test-model',
+			};
+		};
+		return { embedCallCount: () => embedCallCount };
+	}
+
+	test('indexAll should batch embed() calls for multiple uncached nodes when connected', async () => {
+		const stub = stubConnectedAphrodite();
+
+		addNode('n1', 'TableNode', 'Customer orders table');
+		addNode('n2', 'TableNode', 'Product inventory table');
+		addNode('n3', 'TableNode', 'Employee payroll table');
+
+		const count = await searchService.indexAll();
+
+		assert.strictEqual(count, 3);
+		assert.strictEqual(searchService.getIndexedCount(), 3);
+		// All 3 nodes fit within the default maxBatchSize (16), so they
+		// should be embedded in a single batched call, not one per node.
+		assert.strictEqual(stub.embedCallCount(), 1);
+	});
+
+	test('search should batch embed() calls for uncached candidate nodes when connected', async () => {
+		const stub = stubConnectedAphrodite();
+
+		addNode('n1', 'TableNode', 'Customer orders table');
+		addNode('n2', 'TableNode', 'Product inventory table');
+		addNode('n3', 'TableNode', 'Employee payroll table');
+
+		await searchService.search('orders');
+
+		assert.strictEqual(searchService.getIndexedCount(), 3);
+		// One batched call embeds all 3 uncached nodes, plus one more call
+		// to embed the query text itself (via the single-text _embed() path).
+		assert.strictEqual(stub.embedCallCount(), 2);
+	});
+
+	test('indexAll should not re-batch-embed already-indexed nodes on a second pass', async () => {
+		const stub = stubConnectedAphrodite();
+
+		addNode('n1', 'TableNode', 'Customer orders table');
+		addNode('n2', 'TableNode', 'Product inventory table');
+
+		assert.strictEqual(await searchService.indexAll(), 2);
+		assert.strictEqual(stub.embedCallCount(), 1);
+
+		assert.strictEqual(await searchService.indexAll(), 0);
+		// No new embed() calls for the unchanged, already-indexed nodes.
+		assert.strictEqual(stub.embedCallCount(), 1);
+	});
+
+	test('batched embedding should chunk by the configured maxBatchSize', async () => {
+		const stub = stubConnectedAphrodite();
+		aphroditeService.updateConfig({ maxBatchSize: 2 });
+
+		addNode('n1', 'TableNode', 'Customer orders table');
+		addNode('n2', 'TableNode', 'Product inventory table');
+		addNode('n3', 'TableNode', 'Employee payroll table');
+
+		const count = await searchService.indexAll();
+
+		assert.strictEqual(count, 3);
+		// 3 nodes with a batch size of 2 should require 2 embed() calls (2 + 1).
+		assert.strictEqual(stub.embedCallCount(), 2);
+	});
+
+	test('LRU bookkeeping should not affect isIndexed/getIndexedCount for a small node set', async () => {
+		// MAX_INDEX_SIZE is a large hardcoded constant, so eviction itself
+		// isn't practical to exercise directly; this verifies the touch/evict
+		// wiring is a no-op for realistic small-scale usage.
+		addNode('n1', 'TableNode', 'Customer orders table');
+		addNode('n2', 'TableNode', 'Product inventory table');
+
+		await searchService.indexAll();
+		assert.strictEqual(searchService.getIndexedCount(), 2);
+
+		await searchService.search('orders');
+		await searchService.search('inventory');
+
+		assert.strictEqual(searchService.getIndexedCount(), 2);
+		assert.strictEqual(searchService.isIndexed('n1'), true);
+		assert.strictEqual(searchService.isIndexed('n2'), true);
 	});
 });

--- a/src/sql/workbench/services/zonecog/test/browser/hypergraphSemanticSearchService.test.ts
+++ b/src/sql/workbench/services/zonecog/test/browser/hypergraphSemanticSearchService.test.ts
@@ -273,4 +273,23 @@ suite('Hypergraph Semantic Search Service Tests', () => {
 		assert.strictEqual(searchService.isIndexed('n1'), true);
 		assert.strictEqual(searchService.isIndexed('n2'), true);
 	});
+
+	test('a single batch larger than MAX_INDEX_SIZE should not evict entries it just embedded', () => {
+		// Regression coverage: a single indexAll()/search() batch must never
+		// evict a node it just computed a vector for in that same call -
+		// otherwise the caller (search()) silently drops candidates it just
+		// paid to embed. Exceeds the hardcoded 5000-entry cap to exercise the
+		// eviction path against the batch's own entries.
+		const NODE_COUNT = 5005;
+		for (let i = 0; i < NODE_COUNT; i++) {
+			addNode(`n${i}`, 'TableNode', `Orders table variant ${i}`);
+		}
+
+		return searchService.indexAll().then(indexed => {
+			assert.strictEqual(indexed, NODE_COUNT);
+			for (let i = 0; i < NODE_COUNT; i++) {
+				assert.strictEqual(searchService.isIndexed(`n${i}`), true, `n${i} should remain indexed`);
+			}
+		});
+	}).timeout(20000);
 });


### PR DESCRIPTION
# Pull Request Template – Azure Data Studio

## Description

*Provide a clear, concise summary of the changes in this PR. What problem does it solve? Why is it needed? Link any related issues using [issue closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).*

## Code Changes Checklist

- [ ] New or updated **unit tests** added
- [ ] All existing tests pass (`npm run test`)
- [ ] Code follows [contributing guidelines](https://github.com/microsoft/azuredatastudio/blob/main/CONTRIBUTING.md)
- [ ] No UI regressions introduced
- [ ] Logging/telemetry updated if applicable
- [ ] Cross-platform support checked (Windows, macOS, Linux if relevant)

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/azuredatastudio/blob/main/.github/REVIEW_GUIDELINES.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core LLM routing (model/adapter fallback and cancellation) and external engine API calls; mistakes could alter which model serves completions or mask failures, though scope is Zone-Cog services with substantial new unit tests.
> 
> **Overview**
> **Deepens Aphrodite Engine integration** for Zone-Cog (roadmap issue #77): LoRA lifecycle, inference resilience, observability, and faster semantic indexing.
> 
> **`AphroditeService`** now loads/unloads LoRA adapters via vLLM-compatible `/v1/load_lora_adapter` and `/v1/unload_lora_adapter`, tracks active adapters (routed as the `model` field), and exposes adapter listing plus a bounded in-memory telemetry ring buffer with `getTelemetry()`, `getTelemetrySamples()`, and `onDidUpdateTelemetry`. Non-streaming `complete()` walks an ordered model list (active adapter → configured model → `fallbackModels`), records per-attempt telemetry, passes `responseFormat` through as `guided_json`, and **does not** continue the fallback chain on user cancellation (`AbortError`). Streaming `streamComplete()` sends an explicit `model`, supports `guided_json`, and records stream telemetry.
> 
> **`HypergraphSemanticSearchService`** batches uncached node embeddings by `maxBatchSize` instead of one embed per node, and adds LRU eviction (with protection so a batch cannot evict entries it just wrote).
> 
> **Workbench**: three new Command Palette actions—Load LoRA Adapter, Swap Active Model, Show Aphrodite Performance Telemetry.
> 
> Tests cover adapters, telemetry, fallback/cancel behavior, batched embedding, and large-batch eviction; the roadmap marks Aphrodite deep integration complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94bc6c1ba0f2d5367fe6e7723ac13cd4832a0075. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->