### PR TITLE
ZoneCog: tiered hot/cold hypergraph storage (Phase E.2, issue #81)

### DIFF
--- a/docs/ZONECOG_ROADMAP.md
+++ b/docs/ZONECOG_ROADMAP.md
@@ -270,6 +270,15 @@
 - [ ] FlareCog distributed cognitive processing (Phase C) — cross-machine peer discovery, distributed hypergraph federation, and multi-node AAR orchestration remain future work; today's federation/collaboration services are same-machine-only via `BroadcastChannel` (see §3.4, §4.4).
 - [x] Autognosis self-monitoring capabilities — `IAutognosisService`/`AutognosisService` (meta-cognitive layer that synthesizes membrane triad health, embodiment proprioception, and cognitive analytics into a first-person `SelfAssessment` with a verdict, self-confidence score, and detected anomalies; self-wires to `IZoneCogService.onDidProcessQuery` so every processed query triggers a fresh assessment, persisted as `SelfAssessment` hypergraph nodes; `Zone-Cog: Perform Self-Assessment` and `Zone-Cog: Show Self-Assessment History` Command Palette actions)
 
+### 5.4 Enhanced Persistence Layer (Phase E, issue #81)
+
+- [x] Neo4j Cypher export — `HypergraphPersistenceService.exportToCypher()` / `nodesAndLinksToCypher()`
+- [x] OpenCog AtomSpace Scheme export — `HypergraphPersistenceService.exportToAtomSpaceScheme()` / `nodesAndLinksToAtomSpaceScheme()`
+- [x] Tiered (hot/cold) storage with automatic archival of low-salience nodes — `archiveLowSalienceNodes()` moves nodes below a salience threshold (and any links whose every endpoint is also archived) from the live `IHypergraphStore` into a new IndexedDB cold tier (`archiveNodes`/`archiveLinks` stores, DB version 2), shrinking the in-memory working set for large graphs
+- [x] Lazy loading for large graphs — `restoreArchivedNode()` pulls a single archived node (and its own directly-referenced links) back into the live hypergraph on demand, without materializing the rest of the cold tier; `listArchivedNodes()` browses cold-tier contents without loading them. Exposed via `Zone-Cog: Archive Low-Salience Nodes` / `Zone-Cog: Restore Archived Node` Command Palette actions
+- [ ] RocksDB backend option (`E.1`) — would require a new WASM RocksDB dependency and build-system integration; the roadmap's own risk assessment already earmarks IndexedDB as the fallback, so this remains future work
+- [ ] Incremental backup/restore and cloud storage integration (remainder of `E.3`) — future work
+
 ---
 
 ## Dependencies & Prerequisites

--- a/src/sql/workbench/contrib/zonecog/browser/zonecogActions.contribution.ts
+++ b/src/sql/workbench/contrib/zonecog/browser/zonecogActions.contribution.ts
@@ -1074,6 +1074,91 @@ class ZoneCogPersistenceStatsAction extends Action2 {
 	}
 }
 
+/**
+ * Action to archive low-salience nodes out of the live hypergraph into
+ * cold-tier IndexedDB storage.
+ */
+class ZoneCogPersistenceArchiveAction extends Action2 {
+
+	static ID = 'zonecog.persistenceArchive';
+	constructor() {
+		super({
+			id: ZoneCogPersistenceArchiveAction.ID,
+			title: { value: localize('zonecog.persistenceArchive', 'Archive Low-Salience Nodes'), original: 'Archive Low-Salience Nodes' },
+			category: ZONECOG_CATEGORY,
+			icon: Codicon.archive,
+			f1: true,
+			menu: { id: MenuId.CommandPalette },
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const persistenceService = accessor.get(IHypergraphPersistenceService);
+		const notificationService = accessor.get(INotificationService);
+
+		try {
+			const result = await persistenceService.archiveLowSalienceNodes();
+			notificationService.info(localize('zonecog.persistenceArchived',
+				'Archived {0} node(s) and {1} link(s) to cold storage.',
+				result.archivedNodeCount,
+				result.archivedLinkCount
+			));
+		} catch (err) {
+			notificationService.error(localize('zonecog.persistenceArchiveError',
+				'Failed to archive low-salience nodes: {0}', err instanceof Error ? err.message : String(err)));
+		}
+	}
+}
+
+/**
+ * Action to lazily restore a single archived node back into the live hypergraph.
+ */
+class ZoneCogPersistenceRestoreArchivedAction extends Action2 {
+
+	static ID = 'zonecog.persistenceRestoreArchived';
+	constructor() {
+		super({
+			id: ZoneCogPersistenceRestoreArchivedAction.ID,
+			title: { value: localize('zonecog.persistenceRestoreArchived', 'Restore Archived Node'), original: 'Restore Archived Node' },
+			category: ZONECOG_CATEGORY,
+			icon: Codicon.desktopDownload,
+			f1: true,
+			menu: { id: MenuId.CommandPalette },
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const persistenceService = accessor.get(IHypergraphPersistenceService);
+		const notificationService = accessor.get(INotificationService);
+		const quickInputService = accessor.get(IQuickInputService);
+
+		try {
+			const archived = await persistenceService.listArchivedNodes();
+			if (archived.length === 0) {
+				notificationService.info(localize('zonecog.persistenceNoArchivedNodes', 'No nodes are currently archived.'));
+				return;
+			}
+
+			const pick = await quickInputService.pick(
+				archived.map(n => ({ label: n.id, description: `${n.node_type} · salience ${n.salience_score.toFixed(3)}`, detail: n.content })),
+				{ placeHolder: localize('zonecog.persistenceRestoreArchivedPick', 'Select an archived node to restore') }
+			);
+			if (!pick) { return; }
+
+			const restored = await persistenceService.restoreArchivedNode(pick.label);
+			if (!restored) {
+				notificationService.info(localize('zonecog.persistenceRestoreArchivedNotFound', 'Node "{0}" is no longer archived.', pick.label));
+				return;
+			}
+			notificationService.info(localize('zonecog.persistenceRestoredArchived',
+				'Restored node "{0}" to the live hypergraph.', restored.id));
+		} catch (err) {
+			notificationService.error(localize('zonecog.persistenceRestoreArchivedError',
+				'Failed to restore archived node: {0}', err instanceof Error ? err.message : String(err)));
+		}
+	}
+}
+
 // Register all actions
 registerAction2(ZoneCogTestAction);
 registerAction2(ZoneCogToggleThinkingAction);
@@ -1099,6 +1184,8 @@ registerAction2(ZoneCogAARArenaStatusAction);
 registerAction2(ZoneCogPersistenceSaveAction);
 registerAction2(ZoneCogPersistenceLoadAction);
 registerAction2(ZoneCogPersistenceStatsAction);
+registerAction2(ZoneCogPersistenceArchiveAction);
+registerAction2(ZoneCogPersistenceRestoreArchivedAction);
 
 // =============================================================================
 // Phase 5 actions - Schema Perception, Aphrodite Engine

--- a/src/sql/workbench/services/zonecog/browser/hypergraphPersistenceService.ts
+++ b/src/sql/workbench/services/zonecog/browser/hypergraphPersistenceService.ts
@@ -7,6 +7,7 @@ import {
 	IHypergraphPersistenceService,
 	HypergraphSnapshot,
 	PersistenceStats,
+	ArchiveStats,
 } from 'sql/workbench/services/zonecog/common/hypergraphPersistence';
 import { IHypergraphStore, HypergraphNode, HypergraphLink, ICognitiveMembraneService } from 'sql/workbench/services/zonecog/common/zonecogService';
 import { Disposable } from 'vs/base/common/lifecycle';
@@ -18,13 +19,20 @@ import { ILogService } from 'vs/platform/log/common/log';
 // ---------------------------------------------------------------------------
 
 const DB_NAME = 'zonecog-hypergraph';
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 
 const STORE_NODES = 'nodes';
 const STORE_LINKS = 'links';
 const STORE_SNAPSHOTS = 'snapshots';
+/** Cold tier: nodes archived out of the live hypergraph by salience. */
+const STORE_ARCHIVE_NODES = 'archiveNodes';
+/** Cold tier: links archived alongside fully-archived nodes. */
+const STORE_ARCHIVE_LINKS = 'archiveLinks';
 
 const MIN_AUTO_SAVE_INTERVAL_MS = 10_000;
+
+/** Nodes with salience strictly below this are eligible for archival by default. */
+const DEFAULT_ARCHIVE_SALIENCE_THRESHOLD = 0.05;
 
 /**
  * Rough per-record size estimates used for `estimatedBytes` in storage stats.
@@ -55,6 +63,12 @@ function openDatabase(): Promise<IDBDatabase> {
 			if (!db.objectStoreNames.contains(STORE_SNAPSHOTS)) {
 				db.createObjectStore(STORE_SNAPSHOTS, { keyPath: 'id' });
 			}
+			if (!db.objectStoreNames.contains(STORE_ARCHIVE_NODES)) {
+				db.createObjectStore(STORE_ARCHIVE_NODES, { keyPath: 'id' });
+			}
+			if (!db.objectStoreNames.contains(STORE_ARCHIVE_LINKS)) {
+				db.createObjectStore(STORE_ARCHIVE_LINKS, { keyPath: 'id' });
+			}
 		};
 		req.onsuccess = () => resolve(req.result);
 		req.onerror = () => reject(req.error ?? new Error('Failed to open IndexedDB'));
@@ -83,6 +97,24 @@ function idbGetAll<T>(db: IDBDatabase, storeName: string): Promise<T[]> {
 		const store = tx.objectStore(storeName);
 		const req = store.getAll();
 		req.onsuccess = () => resolve(req.result as T[]);
+		req.onerror = () => reject(req.error);
+	});
+}
+
+function idbGet<T>(db: IDBDatabase, storeName: string, key: IDBValidKey): Promise<T | undefined> {
+	return new Promise<T | undefined>((resolve, reject) => {
+		const tx = db.transaction(storeName, 'readonly');
+		const store = tx.objectStore(storeName);
+		const req = store.get(key);
+		req.onsuccess = () => resolve(req.result as T | undefined);
+		req.onerror = () => reject(req.error);
+	});
+}
+
+function idbDelete(store: IDBObjectStore, key: IDBValidKey): Promise<void> {
+	return new Promise<void>((resolve, reject) => {
+		const req = store.delete(key);
+		req.onsuccess = () => resolve();
 		req.onerror = () => reject(req.error);
 	});
 }
@@ -232,10 +264,12 @@ export function nodesAndLinksToAtomSpaceScheme(nodes: ReadonlyArray<HypergraphNo
  * the browser's built-in IndexedDB for durable cross-session persistence.
  *
  * IndexedDB schema:
- *   DB: "zonecog-hypergraph" (version 1)
- *   - nodes     -> HypergraphNode records keyed by id
- *   - links     -> HypergraphLink records keyed by id
- *   - snapshots -> HypergraphSnapshot metadata keyed by id
+ *   DB: "zonecog-hypergraph" (version 2)
+ *   - nodes        -> HypergraphNode records keyed by id (hot tier)
+ *   - links        -> HypergraphLink records keyed by id (hot tier)
+ *   - snapshots    -> HypergraphSnapshot metadata keyed by id
+ *   - archiveNodes -> HypergraphNode records keyed by id (cold tier)
+ *   - archiveLinks -> HypergraphLink records keyed by id (cold tier)
  */
 export class HypergraphPersistenceService extends Disposable implements IHypergraphPersistenceService {
 
@@ -440,14 +474,16 @@ export class HypergraphPersistenceService extends Disposable implements IHypergr
 				lastSaveTime: this._lastSaveTime,
 				lastLoadTime: this._lastLoadTime,
 				estimatedBytes: 0,
+				archivedNodeCount: 0,
 			};
 		}
 
 		const db = await this._getDb();
-		const [nodeCount, linkCount, snapshotCount] = await Promise.all([
+		const [nodeCount, linkCount, snapshotCount, archivedNodeCount] = await Promise.all([
 			idbCount(db, STORE_NODES),
 			idbCount(db, STORE_LINKS),
 			idbCount(db, STORE_SNAPSHOTS),
+			idbCount(db, STORE_ARCHIVE_NODES),
 		]);
 
 		// Rough size estimate based on average record sizes
@@ -461,6 +497,7 @@ export class HypergraphPersistenceService extends Disposable implements IHypergr
 			lastSaveTime: this._lastSaveTime,
 			lastLoadTime: this._lastLoadTime,
 			estimatedBytes,
+			archivedNodeCount,
 		};
 	}
 
@@ -478,6 +515,91 @@ export class HypergraphPersistenceService extends Disposable implements IHypergr
 		const { nodes, links } = this._collectGraph();
 		this.membraneService.recordActivity('autonomic');
 		return nodesAndLinksToAtomSpaceScheme(nodes, links);
+	}
+
+	// -------------------------------------------------------------------------
+	// Tiered storage (hybrid hot/cold hypergraph)
+	// -------------------------------------------------------------------------
+
+	async archiveLowSalienceNodes(threshold = DEFAULT_ARCHIVE_SALIENCE_THRESHOLD): Promise<ArchiveStats> {
+		const db = await this._getDb();
+		const toArchive = this.hypergraphStore.getAllNodes().filter(n => n.salience_score < threshold);
+		if (toArchive.length === 0) {
+			return { archivedNodeCount: 0, archivedLinkCount: 0 };
+		}
+
+		const archiveIds = new Set(toArchive.map(n => n.id));
+
+		// Only archive a link when every one of its outgoing nodes is also
+		// being archived in this pass, so links with a remaining hot endpoint
+		// stay live rather than dangling.
+		const candidateLinkIds = new Set<string>();
+		for (const node of toArchive) {
+			for (const lid of node.links) { candidateLinkIds.add(lid); }
+		}
+		const linksToArchive: HypergraphLink[] = [];
+		for (const lid of candidateLinkIds) {
+			const link = this.hypergraphStore.getLink(lid);
+			if (link && link.outgoing.every(id => archiveIds.has(id))) {
+				linksToArchive.push(link);
+			}
+		}
+
+		const tx = db.transaction([STORE_ARCHIVE_NODES, STORE_ARCHIVE_LINKS], 'readwrite');
+		const archiveNodeStore = tx.objectStore(STORE_ARCHIVE_NODES);
+		const archiveLinkStore = tx.objectStore(STORE_ARCHIVE_LINKS);
+		for (const node of toArchive) { await idbPut(archiveNodeStore, node); }
+		for (const link of linksToArchive) { await idbPut(archiveLinkStore, link); }
+		await new Promise<void>((resolve, reject) => {
+			tx.oncomplete = () => resolve();
+			tx.onerror = () => reject(tx.error);
+		});
+
+		for (const link of linksToArchive) { this.hypergraphStore.removeLink(link.id); }
+		for (const node of toArchive) { this.hypergraphStore.removeNode(node.id); }
+
+		this.logService.info(
+			`HypergraphPersistenceService: archived ${toArchive.length} node(s), ` +
+			`${linksToArchive.length} link(s) below salience ${threshold}`
+		);
+		this.membraneService.recordActivity('autonomic');
+		return { archivedNodeCount: toArchive.length, archivedLinkCount: linksToArchive.length };
+	}
+
+	async restoreArchivedNode(nodeId: string): Promise<HypergraphNode | undefined> {
+		const db = await this._getDb();
+		const node = await idbGet<HypergraphNode>(db, STORE_ARCHIVE_NODES, nodeId);
+		if (!node) { return undefined; }
+
+		const links: HypergraphLink[] = [];
+		for (const linkId of node.links) {
+			const link = await idbGet<HypergraphLink>(db, STORE_ARCHIVE_LINKS, linkId);
+			if (link) { links.push(link); }
+		}
+
+		this.hypergraphStore.addNode(node);
+		for (const link of links) {
+			if (!this.hypergraphStore.getLink(link.id)) {
+				this.hypergraphStore.addLink(link);
+			}
+		}
+
+		const tx = db.transaction([STORE_ARCHIVE_NODES, STORE_ARCHIVE_LINKS], 'readwrite');
+		await idbDelete(tx.objectStore(STORE_ARCHIVE_NODES), nodeId);
+		for (const link of links) { await idbDelete(tx.objectStore(STORE_ARCHIVE_LINKS), link.id); }
+		await new Promise<void>((resolve, reject) => {
+			tx.oncomplete = () => resolve();
+			tx.onerror = () => reject(tx.error);
+		});
+
+		this.logService.info(`HypergraphPersistenceService: restored archived node "${nodeId}" (${links.length} link(s))`);
+		this.membraneService.recordActivity('autonomic');
+		return node;
+	}
+
+	async listArchivedNodes(): Promise<HypergraphNode[]> {
+		const db = await this._getDb();
+		return idbGetAll<HypergraphNode>(db, STORE_ARCHIVE_NODES);
 	}
 
 	// -------------------------------------------------------------------------

--- a/src/sql/workbench/services/zonecog/browser/hypergraphPersistenceService.ts
+++ b/src/sql/workbench/services/zonecog/browser/hypergraphPersistenceService.ts
@@ -285,6 +285,16 @@ export class HypergraphPersistenceService extends Disposable implements IHypergr
 	private _autoSaveIntervalHandle: ReturnType<typeof setInterval> | null = null;
 	private _autoSaveEnabled = false;
 
+	/**
+	 * FIFO chain serializing every operation that reads or mutates the
+	 * hot/cold IndexedDB tiers against the in-memory hypergraph (save, load,
+	 * clearStorage, archiveLowSalienceNodes, restoreArchivedNode). Without
+	 * this, e.g. an auto-save could snapshot the in-memory graph before a
+	 * concurrent archive finishes and then write that stale snapshot back
+	 * over the hot tier, resurrecting nodes the archive just removed.
+	 */
+	private _writeQueue: Promise<unknown> = Promise.resolve();
+
 	private readonly _onDidSave = this._register(new Emitter<HypergraphSnapshot>());
 	readonly onDidSave: Event<HypergraphSnapshot> = this._onDidSave.event;
 
@@ -321,111 +331,117 @@ export class HypergraphPersistenceService extends Disposable implements IHypergr
 	// -------------------------------------------------------------------------
 
 	async save(label = 'manual'): Promise<HypergraphSnapshot> {
-		const db = await this._getDb();
-		const { nodes, links } = this._collectGraph();
+		return this._serialize(async () => {
+			const db = await this._getDb();
+			const { nodes, links } = this._collectGraph();
 
-		const snapshot: HypergraphSnapshot = {
-			id: Date.now(),
-			timestamp: Date.now(),
-			nodeCount: nodes.length,
-			linkCount: links.length,
-			label,
-		};
+			const snapshot: HypergraphSnapshot = {
+				id: Date.now(),
+				timestamp: Date.now(),
+				nodeCount: nodes.length,
+				linkCount: links.length,
+				label,
+			};
 
-		try {
-			// Write nodes, links, snapshot in a single transaction
-			const tx = db.transaction([STORE_NODES, STORE_LINKS, STORE_SNAPSHOTS], 'readwrite');
-			const nodeStore = tx.objectStore(STORE_NODES);
-			const linkStore = tx.objectStore(STORE_LINKS);
-			const snapshotStore = tx.objectStore(STORE_SNAPSHOTS);
+			try {
+				// Write nodes, links, snapshot in a single transaction
+				const tx = db.transaction([STORE_NODES, STORE_LINKS, STORE_SNAPSHOTS], 'readwrite');
+				const nodeStore = tx.objectStore(STORE_NODES);
+				const linkStore = tx.objectStore(STORE_LINKS);
+				const snapshotStore = tx.objectStore(STORE_SNAPSHOTS);
 
-			await idbClear(nodeStore);
-			await idbClear(linkStore);
+				await idbClear(nodeStore);
+				await idbClear(linkStore);
 
-			for (const node of nodes) { await idbPut(nodeStore, node); }
-			for (const link of links) { await idbPut(linkStore, link); }
-			await idbPut(snapshotStore, snapshot);
+				for (const node of nodes) { await idbPut(nodeStore, node); }
+				for (const link of links) { await idbPut(linkStore, link); }
+				await idbPut(snapshotStore, snapshot);
 
+				await new Promise<void>((resolve, reject) => {
+					tx.oncomplete = () => resolve();
+					tx.onerror = () => reject(tx.error);
+				});
+
+				this._lastSaveTime = Date.now();
+				this.logService.info(
+					`HypergraphPersistenceService: saved ${nodes.length} nodes, ` +
+					`${links.length} links (label="${label}")`
+				);
+				this._onDidSave.fire(snapshot);
+				this.membraneService.recordActivity('autonomic');
+				return snapshot;
+			} catch (err) {
+				const msg = String(err);
+				this.logService.error(`HypergraphPersistenceService: save failed - ${msg}`);
+				this._onDidError.fire({ operation: 'save', message: msg });
+				throw err;
+			}
+		});
+	}
+
+	async load(): Promise<HypergraphSnapshot | undefined> {
+		return this._serialize(async () => {
+			const db = await this._getDb();
+
+			const [nodes, links, snapshots] = await Promise.all([
+				idbGetAll<HypergraphNode>(db, STORE_NODES),
+				idbGetAll<HypergraphLink>(db, STORE_LINKS),
+				idbGetAll<HypergraphSnapshot>(db, STORE_SNAPSHOTS),
+			]);
+
+			if (nodes.length === 0 && links.length === 0) {
+				this.logService.info('HypergraphPersistenceService: nothing stored to load');
+				return undefined;
+			}
+
+			// Restore into in-memory store
+			this.hypergraphStore.clear();
+			for (const node of nodes) { this.hypergraphStore.addNode(node); }
+			for (const link of links) { this.hypergraphStore.addLink(link); }
+
+			const latestSnapshot = snapshots.sort((a, b) => b.timestamp - a.timestamp)[0];
+			this._lastLoadTime = Date.now();
+
+			this.logService.info(
+				`HypergraphPersistenceService: loaded ${nodes.length} nodes, ${links.length} links`
+			);
+			this.membraneService.recordActivity('autonomic');
+
+			if (latestSnapshot) {
+				this._onDidLoad.fire(latestSnapshot);
+				return latestSnapshot;
+			}
+
+			// Synthesise a snapshot record if none exists
+			const synthetic: HypergraphSnapshot = {
+				id: 0,
+				timestamp: this._lastLoadTime,
+				nodeCount: nodes.length,
+				linkCount: links.length,
+				label: 'restored',
+			};
+			this._onDidLoad.fire(synthetic);
+			return synthetic;
+		});
+	}
+
+	async clearStorage(): Promise<void> {
+		return this._serialize(async () => {
+			const db = await this._getDb();
+			const tx = db.transaction([STORE_NODES, STORE_LINKS, STORE_SNAPSHOTS, STORE_ARCHIVE_NODES, STORE_ARCHIVE_LINKS], 'readwrite');
+			await Promise.all([
+				idbClear(tx.objectStore(STORE_NODES)),
+				idbClear(tx.objectStore(STORE_LINKS)),
+				idbClear(tx.objectStore(STORE_SNAPSHOTS)),
+				idbClear(tx.objectStore(STORE_ARCHIVE_NODES)),
+				idbClear(tx.objectStore(STORE_ARCHIVE_LINKS)),
+			]);
 			await new Promise<void>((resolve, reject) => {
 				tx.oncomplete = () => resolve();
 				tx.onerror = () => reject(tx.error);
 			});
-
-			this._lastSaveTime = Date.now();
-			this.logService.info(
-				`HypergraphPersistenceService: saved ${nodes.length} nodes, ` +
-				`${links.length} links (label="${label}")`
-			);
-			this._onDidSave.fire(snapshot);
-			this.membraneService.recordActivity('autonomic');
-			return snapshot;
-		} catch (err) {
-			const msg = String(err);
-			this.logService.error(`HypergraphPersistenceService: save failed - ${msg}`);
-			this._onDidError.fire({ operation: 'save', message: msg });
-			throw err;
-		}
-	}
-
-	async load(): Promise<HypergraphSnapshot | undefined> {
-		const db = await this._getDb();
-
-		const [nodes, links, snapshots] = await Promise.all([
-			idbGetAll<HypergraphNode>(db, STORE_NODES),
-			idbGetAll<HypergraphLink>(db, STORE_LINKS),
-			idbGetAll<HypergraphSnapshot>(db, STORE_SNAPSHOTS),
-		]);
-
-		if (nodes.length === 0 && links.length === 0) {
-			this.logService.info('HypergraphPersistenceService: nothing stored to load');
-			return undefined;
-		}
-
-		// Restore into in-memory store
-		this.hypergraphStore.clear();
-		for (const node of nodes) { this.hypergraphStore.addNode(node); }
-		for (const link of links) { this.hypergraphStore.addLink(link); }
-
-		const latestSnapshot = snapshots.sort((a, b) => b.timestamp - a.timestamp)[0];
-		this._lastLoadTime = Date.now();
-
-		this.logService.info(
-			`HypergraphPersistenceService: loaded ${nodes.length} nodes, ${links.length} links`
-		);
-		this.membraneService.recordActivity('autonomic');
-
-		if (latestSnapshot) {
-			this._onDidLoad.fire(latestSnapshot);
-			return latestSnapshot;
-		}
-
-		// Synthesise a snapshot record if none exists
-		const synthetic: HypergraphSnapshot = {
-			id: 0,
-			timestamp: this._lastLoadTime,
-			nodeCount: nodes.length,
-			linkCount: links.length,
-			label: 'restored',
-		};
-		this._onDidLoad.fire(synthetic);
-		return synthetic;
-	}
-
-	async clearStorage(): Promise<void> {
-		const db = await this._getDb();
-		const tx = db.transaction([STORE_NODES, STORE_LINKS, STORE_SNAPSHOTS, STORE_ARCHIVE_NODES, STORE_ARCHIVE_LINKS], 'readwrite');
-		await Promise.all([
-			idbClear(tx.objectStore(STORE_NODES)),
-			idbClear(tx.objectStore(STORE_LINKS)),
-			idbClear(tx.objectStore(STORE_SNAPSHOTS)),
-			idbClear(tx.objectStore(STORE_ARCHIVE_NODES)),
-			idbClear(tx.objectStore(STORE_ARCHIVE_LINKS)),
-		]);
-		await new Promise<void>((resolve, reject) => {
-			tx.oncomplete = () => resolve();
-			tx.onerror = () => reject(tx.error);
+			this.logService.info('HypergraphPersistenceService: storage cleared');
 		});
-		this.logService.info('HypergraphPersistenceService: storage cleared');
 	}
 
 	async listSnapshots(): Promise<HypergraphSnapshot[]> {
@@ -524,110 +540,127 @@ export class HypergraphPersistenceService extends Disposable implements IHypergr
 	// -------------------------------------------------------------------------
 
 	async archiveLowSalienceNodes(threshold = DEFAULT_ARCHIVE_SALIENCE_THRESHOLD): Promise<ArchiveStats> {
-		const db = await this._getDb();
-		const toArchive = this.hypergraphStore.getAllNodes().filter(n => n.salience_score < threshold);
-		if (toArchive.length === 0) {
-			return { archivedNodeCount: 0, archivedLinkCount: 0 };
-		}
-
-		const archiveIds = new Set(toArchive.map(n => n.id));
-
-		// Only archive a link when every one of its outgoing nodes is also
-		// being archived in this pass, so links with a remaining hot endpoint
-		// stay live rather than dangling.
-		const candidateLinkIds = new Set<string>();
-		for (const node of toArchive) {
-			for (const lid of node.links) { candidateLinkIds.add(lid); }
-		}
-		const linksToArchive: HypergraphLink[] = [];
-		for (const lid of candidateLinkIds) {
-			const link = this.hypergraphStore.getLink(lid);
-			if (link && link.outgoing.every(id => archiveIds.has(id))) {
-				linksToArchive.push(link);
+		return this._serialize(async () => {
+			const db = await this._getDb();
+			const toArchive = this.hypergraphStore.getAllNodes().filter(n => n.salience_score < threshold);
+			if (toArchive.length === 0) {
+				return { archivedNodeCount: 0, archivedLinkCount: 0 };
 			}
-		}
 
-		// Move the records: write into the cold tier and delete from the hot
-		// tier in the same transaction, so a later load() (which rebuilds
-		// memory from the hot IndexedDB stores) can't resurrect them.
-		const tx = db.transaction([STORE_NODES, STORE_LINKS, STORE_ARCHIVE_NODES, STORE_ARCHIVE_LINKS], 'readwrite');
-		const nodeStore = tx.objectStore(STORE_NODES);
-		const linkStore = tx.objectStore(STORE_LINKS);
-		const archiveNodeStore = tx.objectStore(STORE_ARCHIVE_NODES);
-		const archiveLinkStore = tx.objectStore(STORE_ARCHIVE_LINKS);
-		for (const node of toArchive) {
-			await idbPut(archiveNodeStore, node);
-			await idbDelete(nodeStore, node.id);
-		}
-		for (const link of linksToArchive) {
-			await idbPut(archiveLinkStore, link);
-			await idbDelete(linkStore, link.id);
-		}
-		await new Promise<void>((resolve, reject) => {
-			tx.oncomplete = () => resolve();
-			tx.onerror = () => reject(tx.error);
+			const archiveIds = new Set(toArchive.map(n => n.id));
+
+			// Only archive a link when every one of its outgoing nodes is also
+			// being archived in this pass, so links with a remaining hot endpoint
+			// stay live rather than dangling.
+			const candidateLinkIds = new Set<string>();
+			for (const node of toArchive) {
+				for (const lid of node.links) { candidateLinkIds.add(lid); }
+			}
+			const linksToArchive: HypergraphLink[] = [];
+			for (const lid of candidateLinkIds) {
+				const link = this.hypergraphStore.getLink(lid);
+				if (link && link.outgoing.every(id => archiveIds.has(id))) {
+					linksToArchive.push(link);
+				}
+			}
+
+			// Move the records: write into the cold tier and delete from the hot
+			// tier in the same transaction, so a later load() (which rebuilds
+			// memory from the hot IndexedDB stores) can't resurrect them.
+			const tx = db.transaction([STORE_NODES, STORE_LINKS, STORE_ARCHIVE_NODES, STORE_ARCHIVE_LINKS], 'readwrite');
+			const nodeStore = tx.objectStore(STORE_NODES);
+			const linkStore = tx.objectStore(STORE_LINKS);
+			const archiveNodeStore = tx.objectStore(STORE_ARCHIVE_NODES);
+			const archiveLinkStore = tx.objectStore(STORE_ARCHIVE_LINKS);
+			for (const node of toArchive) {
+				await idbPut(archiveNodeStore, node);
+				await idbDelete(nodeStore, node.id);
+			}
+			for (const link of linksToArchive) {
+				await idbPut(archiveLinkStore, link);
+				await idbDelete(linkStore, link.id);
+			}
+			await new Promise<void>((resolve, reject) => {
+				tx.oncomplete = () => resolve();
+				tx.onerror = () => reject(tx.error);
+			});
+
+			for (const link of linksToArchive) { this.hypergraphStore.removeLink(link.id); }
+			for (const node of toArchive) { this.hypergraphStore.removeNode(node.id); }
+
+			this.logService.info(
+				`HypergraphPersistenceService: archived ${toArchive.length} node(s), ` +
+				`${linksToArchive.length} link(s) below salience ${threshold}`
+			);
+			this.membraneService.recordActivity('autonomic');
+			return { archivedNodeCount: toArchive.length, archivedLinkCount: linksToArchive.length };
 		});
-
-		for (const link of linksToArchive) { this.hypergraphStore.removeLink(link.id); }
-		for (const node of toArchive) { this.hypergraphStore.removeNode(node.id); }
-
-		this.logService.info(
-			`HypergraphPersistenceService: archived ${toArchive.length} node(s), ` +
-			`${linksToArchive.length} link(s) below salience ${threshold}`
-		);
-		this.membraneService.recordActivity('autonomic');
-		return { archivedNodeCount: toArchive.length, archivedLinkCount: linksToArchive.length };
 	}
 
 	async restoreArchivedNode(nodeId: string): Promise<HypergraphNode | undefined> {
-		const db = await this._getDb();
-		const node = await idbGet<HypergraphNode>(db, STORE_ARCHIVE_NODES, nodeId);
-		if (!node) { return undefined; }
+		return this._serialize(async () => {
+			const db = await this._getDb();
+			const node = await idbGet<HypergraphNode>(db, STORE_ARCHIVE_NODES, nodeId);
+			if (!node) { return undefined; }
 
-		const links: HypergraphLink[] = [];
-		for (const linkId of node.links) {
-			const link = await idbGet<HypergraphLink>(db, STORE_ARCHIVE_LINKS, linkId);
-			if (link) { links.push(link); }
-		}
-
-		// A link is only safe to drop from cold storage once no *other*
-		// still-archived node references it - otherwise that other node
-		// would lose its only durable copy of a link it hasn't been
-		// restored alongside.
-		const otherArchivedNodes = (await idbGetAll<HypergraphNode>(db, STORE_ARCHIVE_NODES)).filter(n => n.id !== nodeId);
-		const stillReferencedInArchive = new Set<string>();
-		for (const other of otherArchivedNodes) {
-			for (const lid of other.links) { stillReferencedInArchive.add(lid); }
-		}
-		const linksToDropFromArchive = links.filter(l => !stillReferencedInArchive.has(l.id));
-
-		this.hypergraphStore.addNode(node);
-		for (const link of links) {
-			if (!this.hypergraphStore.getLink(link.id)) {
-				this.hypergraphStore.addLink(link);
+			const links: HypergraphLink[] = [];
+			for (const linkId of node.links) {
+				const link = await idbGet<HypergraphLink>(db, STORE_ARCHIVE_LINKS, linkId);
+				if (link) { links.push(link); }
 			}
-		}
 
-		// Write the restored records into the hot tier and remove the node
-		// (plus any link no other archived node still needs) from the cold
-		// tier, so the restore is durable without requiring a separate
-		// save() call before the next load().
-		const tx = db.transaction([STORE_NODES, STORE_LINKS, STORE_ARCHIVE_NODES, STORE_ARCHIVE_LINKS], 'readwrite');
-		await idbPut(tx.objectStore(STORE_NODES), node);
-		for (const link of links) { await idbPut(tx.objectStore(STORE_LINKS), link); }
-		await idbDelete(tx.objectStore(STORE_ARCHIVE_NODES), nodeId);
-		for (const link of linksToDropFromArchive) { await idbDelete(tx.objectStore(STORE_ARCHIVE_LINKS), link.id); }
-		await new Promise<void>((resolve, reject) => {
-			tx.oncomplete = () => resolve();
-			tx.onerror = () => reject(tx.error);
+			// A link is only safe to drop from cold storage once no *other*
+			// still-archived node references it - otherwise that other node
+			// would lose its only durable copy of a link it hasn't been
+			// restored alongside.
+			const otherArchivedNodes = (await idbGetAll<HypergraphNode>(db, STORE_ARCHIVE_NODES)).filter(n => n.id !== nodeId);
+			const stillReferencedInArchive = new Set<string>();
+			for (const other of otherArchivedNodes) {
+				for (const lid of other.links) { stillReferencedInArchive.add(lid); }
+			}
+			const linksToDropFromArchive = links.filter(l => !stillReferencedInArchive.has(l.id));
+
+			this.hypergraphStore.addNode(node);
+			for (const link of links) {
+				if (!this.hypergraphStore.getLink(link.id)) {
+					this.hypergraphStore.addLink(link);
+				}
+			}
+
+			// A link only belongs in the hot tier once every one of its
+			// outgoing nodes is actually live - otherwise it would sit in hot
+			// storage referencing a still-archived node. If that stale
+			// endpoint (this restored node, still below the salience
+			// threshold) gets archived again later, archiveLowSalienceNodes()
+			// only pulls a link out of the hot tier when *all* of its
+			// outgoing ids are in that pass; a link whose other endpoint was
+			// never live wouldn't qualify, leaving it permanently orphaned in
+			// hot storage. Links with a still-cold endpoint stay purely
+			// in-memory for this session instead (an explicit save() while
+			// all endpoints happen to be live will persist it normally).
+			const hotLinks = links.filter(l => l.outgoing.every(id => this.hypergraphStore.getNode(id) !== undefined));
+
+			// Write the restored records into the hot tier and remove the node
+			// (plus any link no other archived node still needs) from the cold
+			// tier, so the restore is durable without requiring a separate
+			// save() call before the next load().
+			const tx = db.transaction([STORE_NODES, STORE_LINKS, STORE_ARCHIVE_NODES, STORE_ARCHIVE_LINKS], 'readwrite');
+			await idbPut(tx.objectStore(STORE_NODES), node);
+			for (const link of hotLinks) { await idbPut(tx.objectStore(STORE_LINKS), link); }
+			await idbDelete(tx.objectStore(STORE_ARCHIVE_NODES), nodeId);
+			for (const link of linksToDropFromArchive) { await idbDelete(tx.objectStore(STORE_ARCHIVE_LINKS), link.id); }
+			await new Promise<void>((resolve, reject) => {
+				tx.oncomplete = () => resolve();
+				tx.onerror = () => reject(tx.error);
+			});
+
+			this.logService.info(
+				`HypergraphPersistenceService: restored archived node "${nodeId}" ` +
+				`(${links.length} link(s), ${linksToDropFromArchive.length} removed from cold storage)`
+			);
+			this.membraneService.recordActivity('autonomic');
+			return node;
 		});
-
-		this.logService.info(
-			`HypergraphPersistenceService: restored archived node "${nodeId}" ` +
-			`(${links.length} link(s), ${linksToDropFromArchive.length} removed from cold storage)`
-		);
-		this.membraneService.recordActivity('autonomic');
-		return node;
 	}
 
 	async listArchivedNodes(): Promise<HypergraphNode[]> {
@@ -661,6 +694,16 @@ export class HypergraphPersistenceService extends Disposable implements IHypergr
 			return db;
 		});
 		return this._dbOpenPromise;
+	}
+
+	/**
+	 * Run `operation` only after every previously-queued operation has
+	 * settled, so hot/cold-tier reads and writes never interleave.
+	 */
+	private _serialize<T>(operation: () => Promise<T>): Promise<T> {
+		const result = this._writeQueue.then(operation, operation);
+		this._writeQueue = result.then(() => undefined, () => undefined);
+		return result;
 	}
 
 	/**

--- a/src/sql/workbench/services/zonecog/browser/hypergraphPersistenceService.ts
+++ b/src/sql/workbench/services/zonecog/browser/hypergraphPersistenceService.ts
@@ -413,11 +413,13 @@ export class HypergraphPersistenceService extends Disposable implements IHypergr
 
 	async clearStorage(): Promise<void> {
 		const db = await this._getDb();
-		const tx = db.transaction([STORE_NODES, STORE_LINKS, STORE_SNAPSHOTS], 'readwrite');
+		const tx = db.transaction([STORE_NODES, STORE_LINKS, STORE_SNAPSHOTS, STORE_ARCHIVE_NODES, STORE_ARCHIVE_LINKS], 'readwrite');
 		await Promise.all([
 			idbClear(tx.objectStore(STORE_NODES)),
 			idbClear(tx.objectStore(STORE_LINKS)),
 			idbClear(tx.objectStore(STORE_SNAPSHOTS)),
+			idbClear(tx.objectStore(STORE_ARCHIVE_NODES)),
+			idbClear(tx.objectStore(STORE_ARCHIVE_LINKS)),
 		]);
 		await new Promise<void>((resolve, reject) => {
 			tx.oncomplete = () => resolve();
@@ -545,11 +547,22 @@ export class HypergraphPersistenceService extends Disposable implements IHypergr
 			}
 		}
 
-		const tx = db.transaction([STORE_ARCHIVE_NODES, STORE_ARCHIVE_LINKS], 'readwrite');
+		// Move the records: write into the cold tier and delete from the hot
+		// tier in the same transaction, so a later load() (which rebuilds
+		// memory from the hot IndexedDB stores) can't resurrect them.
+		const tx = db.transaction([STORE_NODES, STORE_LINKS, STORE_ARCHIVE_NODES, STORE_ARCHIVE_LINKS], 'readwrite');
+		const nodeStore = tx.objectStore(STORE_NODES);
+		const linkStore = tx.objectStore(STORE_LINKS);
 		const archiveNodeStore = tx.objectStore(STORE_ARCHIVE_NODES);
 		const archiveLinkStore = tx.objectStore(STORE_ARCHIVE_LINKS);
-		for (const node of toArchive) { await idbPut(archiveNodeStore, node); }
-		for (const link of linksToArchive) { await idbPut(archiveLinkStore, link); }
+		for (const node of toArchive) {
+			await idbPut(archiveNodeStore, node);
+			await idbDelete(nodeStore, node.id);
+		}
+		for (const link of linksToArchive) {
+			await idbPut(archiveLinkStore, link);
+			await idbDelete(linkStore, link.id);
+		}
 		await new Promise<void>((resolve, reject) => {
 			tx.oncomplete = () => resolve();
 			tx.onerror = () => reject(tx.error);
@@ -577,6 +590,17 @@ export class HypergraphPersistenceService extends Disposable implements IHypergr
 			if (link) { links.push(link); }
 		}
 
+		// A link is only safe to drop from cold storage once no *other*
+		// still-archived node references it - otherwise that other node
+		// would lose its only durable copy of a link it hasn't been
+		// restored alongside.
+		const otherArchivedNodes = (await idbGetAll<HypergraphNode>(db, STORE_ARCHIVE_NODES)).filter(n => n.id !== nodeId);
+		const stillReferencedInArchive = new Set<string>();
+		for (const other of otherArchivedNodes) {
+			for (const lid of other.links) { stillReferencedInArchive.add(lid); }
+		}
+		const linksToDropFromArchive = links.filter(l => !stillReferencedInArchive.has(l.id));
+
 		this.hypergraphStore.addNode(node);
 		for (const link of links) {
 			if (!this.hypergraphStore.getLink(link.id)) {
@@ -584,15 +608,24 @@ export class HypergraphPersistenceService extends Disposable implements IHypergr
 			}
 		}
 
-		const tx = db.transaction([STORE_ARCHIVE_NODES, STORE_ARCHIVE_LINKS], 'readwrite');
+		// Write the restored records into the hot tier and remove the node
+		// (plus any link no other archived node still needs) from the cold
+		// tier, so the restore is durable without requiring a separate
+		// save() call before the next load().
+		const tx = db.transaction([STORE_NODES, STORE_LINKS, STORE_ARCHIVE_NODES, STORE_ARCHIVE_LINKS], 'readwrite');
+		await idbPut(tx.objectStore(STORE_NODES), node);
+		for (const link of links) { await idbPut(tx.objectStore(STORE_LINKS), link); }
 		await idbDelete(tx.objectStore(STORE_ARCHIVE_NODES), nodeId);
-		for (const link of links) { await idbDelete(tx.objectStore(STORE_ARCHIVE_LINKS), link.id); }
+		for (const link of linksToDropFromArchive) { await idbDelete(tx.objectStore(STORE_ARCHIVE_LINKS), link.id); }
 		await new Promise<void>((resolve, reject) => {
 			tx.oncomplete = () => resolve();
 			tx.onerror = () => reject(tx.error);
 		});
 
-		this.logService.info(`HypergraphPersistenceService: restored archived node "${nodeId}" (${links.length} link(s))`);
+		this.logService.info(
+			`HypergraphPersistenceService: restored archived node "${nodeId}" ` +
+			`(${links.length} link(s), ${linksToDropFromArchive.length} removed from cold storage)`
+		);
 		this.membraneService.recordActivity('autonomic');
 		return node;
 	}

--- a/src/sql/workbench/services/zonecog/common/hypergraphPersistence.ts
+++ b/src/sql/workbench/services/zonecog/common/hypergraphPersistence.ts
@@ -5,6 +5,7 @@
 
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { Event } from 'vs/base/common/event';
+import { HypergraphNode } from 'sql/workbench/services/zonecog/common/zonecogService';
 
 export const IHypergraphPersistenceService = createDecorator<IHypergraphPersistenceService>('hypergraphPersistenceService');
 
@@ -46,6 +47,19 @@ export interface PersistenceStats {
 	lastLoadTime: number;
 	/** Estimated storage size in bytes (best-effort). */
 	estimatedBytes: number;
+	/** Number of nodes currently held in cold-tier archive storage. */
+	archivedNodeCount: number;
+}
+
+/**
+ * Result of an {@link IHypergraphPersistenceService.archiveLowSalienceNodes}
+ * pass.
+ */
+export interface ArchiveStats {
+	/** Number of nodes moved from the live hypergraph into cold storage. */
+	archivedNodeCount: number;
+	/** Number of links moved alongside them (every outgoing id also archived). */
+	archivedLinkCount: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -165,6 +179,36 @@ export interface IHypergraphPersistenceService {
 	 * `ConceptNode` references to its outgoing node ids.
 	 */
 	exportToAtomSpaceScheme(): string;
+
+	// -- Tiered storage (hybrid hot/cold hypergraph) --------------------------
+
+	/**
+	 * Move nodes whose `salience_score` is below `threshold` out of the live
+	 * in-memory hypergraph and into cold-tier IndexedDB storage, shrinking
+	 * the working set for large graphs. A link is archived alongside its
+	 * nodes only when every one of its `outgoing` ids is also being archived
+	 * in the same pass; links with a remaining hot endpoint are left live.
+	 * Archived nodes/links are removed from the in-memory `IHypergraphStore`
+	 * but remain durably retrievable via {@link restoreArchivedNode}.
+	 *
+	 * @param threshold Salience cutoff, exclusive. Defaults to a low,
+	 *   service-defined constant if omitted.
+	 */
+	archiveLowSalienceNodes(threshold?: number): Promise<ArchiveStats>;
+
+	/**
+	 * Lazily restore a single archived node - and any links archived
+	 * alongside it that this node itself references - back into the live
+	 * in-memory hypergraph, without loading the rest of the cold tier.
+	 * @returns The restored node, or undefined if no archived node has this id.
+	 */
+	restoreArchivedNode(nodeId: string): Promise<HypergraphNode | undefined>;
+
+	/**
+	 * List all archived (cold-tier) node records without loading them into
+	 * the live hypergraph.
+	 */
+	listArchivedNodes(): Promise<HypergraphNode[]>;
 
 	/**
 	 * Dispose of the service and release any resources.

--- a/src/sql/workbench/services/zonecog/common/hyperon.ts
+++ b/src/sql/workbench/services/zonecog/common/hyperon.ts
@@ -172,7 +172,7 @@ export interface IHyperonService {
 
 	/**
 	 * Execute the PLN deduction rule natively in MeTTa over the current
-	 * hypergraph (A→B, B→C ⊢ A→C with the full strength formula using node
+	 * hypergraph (A→B, B→C |- A→C with the full strength formula using node
 	 * salience priors), persist each surviving conclusion as an `Inferred`
 	 * hypergraph link, and register its truth value with the PLN reasoning
 	 * service so subsequent URE passes build on the MeTTa-derived results.

--- a/src/sql/workbench/services/zonecog/test/browser/hypergraphPersistenceService.test.ts
+++ b/src/sql/workbench/services/zonecog/test/browser/hypergraphPersistenceService.test.ts
@@ -592,6 +592,49 @@ suite('Hypergraph Persistence Service Tests', () => {
 		assert.strictEqual(mockDb.getStore('archiveLinks').getSize(), 0, 'link should be dropped from cold storage once no archived node needs it');
 		assert.ok(hypergraphStore.getLink('shared-link'), 'both endpoints restored, link should be live');
 	});
+
+	test('should not orphan a shared link in the hot store when its restored endpoint is re-archived', async () => {
+		hypergraphStore.addNode({
+			id: 'reorph-a', node_type: 'T', content: '', links: ['reorph-link'], metadata: {}, salience_score: 0.01,
+		});
+		hypergraphStore.addNode({
+			id: 'reorph-b', node_type: 'T', content: '', links: ['reorph-link'], metadata: {}, salience_score: 0.01,
+		});
+		hypergraphStore.addLink({ id: 'reorph-link', link_type: 'L', outgoing: ['reorph-a', 'reorph-b'], metadata: {} });
+		await persistenceService.archiveLowSalienceNodes(0.05);
+
+		// Restore only reorph-a; reorph-b (and thus one endpoint of the link)
+		// stays cold, so the link must not be written into the hot store yet.
+		await persistenceService.restoreArchivedNode('reorph-a');
+		assert.strictEqual(mockDb.getStore('links').getSize(), 0, 'link with a still-cold endpoint should not enter the hot tier');
+
+		// reorph-a is still below the threshold, so a second archive pass
+		// picks it back up. If the link had leaked into the hot store above,
+		// this pass would leave it there forever (its other endpoint,
+		// reorph-b, was never live and so is never in this pass's archiveIds).
+		await persistenceService.archiveLowSalienceNodes(0.05);
+		assert.strictEqual(mockDb.getStore('links').getSize(), 0, 'link must not be orphaned in the hot store after re-archiving its endpoint');
+
+		hypergraphStore.clear();
+		const loaded = await persistenceService.load();
+		assert.ok(loaded);
+		assert.strictEqual(hypergraphStore.getLink('reorph-link'), undefined, 'load() must not resurrect an orphaned link');
+	});
+
+	test('should serialize save() and archiveLowSalienceNodes() so a concurrent save cannot resurrect an archived node', async () => {
+		hypergraphStore.addNode({
+			id: 'race-node', node_type: 'T', content: '', links: [], metadata: {}, salience_score: 0.01,
+		});
+
+		// Fire both without awaiting the first, mirroring an auto-save
+		// landing while an archive pass is in flight.
+		const savePromise = persistenceService.save('race-save');
+		const archivePromise = persistenceService.archiveLowSalienceNodes(0.05);
+		await Promise.all([savePromise, archivePromise]);
+
+		assert.strictEqual(mockDb.getStore('nodes').getSize(), 0, 'archived node must not be resurrected by a racing save()');
+		assert.strictEqual(hypergraphStore.getNode('race-node'), undefined);
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/src/sql/workbench/services/zonecog/test/browser/hypergraphPersistenceService.test.ts
+++ b/src/sql/workbench/services/zonecog/test/browser/hypergraphPersistenceService.test.ts
@@ -614,11 +614,7 @@ suite('Hypergraph Persistence Service Tests', () => {
 		// reorph-b, was never live and so is never in this pass's archiveIds).
 		await persistenceService.archiveLowSalienceNodes(0.05);
 		assert.strictEqual(mockDb.getStore('links').getSize(), 0, 'link must not be orphaned in the hot store after re-archiving its endpoint');
-
-		hypergraphStore.clear();
-		const loaded = await persistenceService.load();
-		assert.ok(loaded);
-		assert.strictEqual(hypergraphStore.getLink('reorph-link'), undefined, 'load() must not resurrect an orphaned link');
+		assert.strictEqual(mockDb.getStore('nodes').getSize(), 0, 'both endpoints should be back in cold storage with nothing left hot');
 	});
 
 	test('should serialize save() and archiveLowSalienceNodes() so a concurrent save cannot resurrect an archived node', async () => {

--- a/src/sql/workbench/services/zonecog/test/browser/hypergraphPersistenceService.test.ts
+++ b/src/sql/workbench/services/zonecog/test/browser/hypergraphPersistenceService.test.ts
@@ -530,6 +530,68 @@ suite('Hypergraph Persistence Service Tests', () => {
 		const stats = await persistenceService.getStats();
 		assert.strictEqual(stats.archivedNodeCount, 1);
 	});
+
+	test('should remove archived nodes and links from the hot store so load() does not resurrect them', async () => {
+		hypergraphStore.addNode({
+			id: 'hot-then-cold', node_type: 'T', content: '', links: [], metadata: {}, salience_score: 0.01,
+		});
+		hypergraphStore.addNode({
+			id: 'stays-hot', node_type: 'T', content: '', links: [], metadata: {}, salience_score: 0.9,
+		});
+		await persistenceService.save();
+
+		await persistenceService.archiveLowSalienceNodes(0.05);
+
+		hypergraphStore.clear();
+		const loaded = await persistenceService.load();
+		assert.ok(loaded);
+		assert.strictEqual(hypergraphStore.getNode('hot-then-cold'), undefined, 'archived node must not resurrect from the hot store');
+		assert.ok(hypergraphStore.getNode('stays-hot'), 'node above the threshold should still load normally');
+	});
+
+	test('should persist a restored node into the hot store without requiring an explicit save', async () => {
+		hypergraphStore.addNode({
+			id: 'durable-restore', node_type: 'T', content: '', links: [], metadata: {}, salience_score: 0.01,
+		});
+		await persistenceService.archiveLowSalienceNodes(0.05);
+		await persistenceService.restoreArchivedNode('durable-restore');
+
+		hypergraphStore.clear();
+		const loaded = await persistenceService.load();
+		assert.ok(loaded);
+		assert.ok(hypergraphStore.getNode('durable-restore'), 'restored node should survive a load() without an intervening save()');
+	});
+
+	test('should clear archived nodes and links together with the hot tier', async () => {
+		hypergraphStore.addNode({
+			id: 'clear-cold', node_type: 'T', content: '', links: [], metadata: {}, salience_score: 0.01,
+		});
+		await persistenceService.archiveLowSalienceNodes(0.05);
+
+		await persistenceService.clearStorage();
+
+		const archived = await persistenceService.listArchivedNodes();
+		assert.strictEqual(archived.length, 0);
+		assert.strictEqual(mockDb.getStore('archiveNodes').getSize(), 0);
+	});
+
+	test('should keep a cold link archived while another archived node still references it', async () => {
+		hypergraphStore.addNode({
+			id: 'shared-a', node_type: 'T', content: '', links: ['shared-link'], metadata: {}, salience_score: 0.01,
+		});
+		hypergraphStore.addNode({
+			id: 'shared-b', node_type: 'T', content: '', links: ['shared-link'], metadata: {}, salience_score: 0.01,
+		});
+		hypergraphStore.addLink({ id: 'shared-link', link_type: 'L', outgoing: ['shared-a', 'shared-b'], metadata: {} });
+		await persistenceService.archiveLowSalienceNodes(0.05);
+
+		await persistenceService.restoreArchivedNode('shared-a');
+		assert.strictEqual(mockDb.getStore('archiveLinks').getSize(), 1, 'link should stay archived while shared-b still needs it');
+
+		await persistenceService.restoreArchivedNode('shared-b');
+		assert.strictEqual(mockDb.getStore('archiveLinks').getSize(), 0, 'link should be dropped from cold storage once no archived node needs it');
+		assert.ok(hypergraphStore.getLink('shared-link'), 'both endpoints restored, link should be live');
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/src/sql/workbench/services/zonecog/test/browser/hypergraphPersistenceService.test.ts
+++ b/src/sql/workbench/services/zonecog/test/browser/hypergraphPersistenceService.test.ts
@@ -70,6 +70,24 @@ class MockIDBObjectStore {
 		return req;
 	}
 
+	get(key: string): { onsuccess: (() => void) | null; onerror: ((e: unknown) => void) | null; result: IDBRecord | undefined } {
+		const result = this._data.get(String(key));
+		const req = {
+			onsuccess: null as (() => void) | null,
+			onerror: null as ((e: unknown) => void) | null,
+			result,
+		};
+		scheduleCallback(() => req.onsuccess?.());
+		return req;
+	}
+
+	delete(key: string): { onsuccess: (() => void) | null; onerror: ((e: unknown) => void) | null } {
+		this._data.delete(String(key));
+		const req = { onsuccess: null as (() => void) | null, onerror: null as ((e: unknown) => void) | null };
+		scheduleCallback(() => req.onsuccess?.());
+		return req;
+	}
+
 	count(): { onsuccess: (() => void) | null; onerror: ((e: unknown) => void) | null; result: number } {
 		const result = this._data.size;
 		const req = {
@@ -126,6 +144,8 @@ class MockIDBDatabase {
 		['nodes', new MockIDBObjectStore('id')],
 		['links', new MockIDBObjectStore('id')],
 		['snapshots', new MockIDBObjectStore('id')],
+		['archiveNodes', new MockIDBObjectStore('id')],
+		['archiveLinks', new MockIDBObjectStore('id')],
 	]);
 
 	objectStoreNames = { contains: (_name: string) => true };
@@ -416,6 +436,99 @@ suite('Hypergraph Persistence Service Tests', () => {
 		persistenceService.exportToCypher();
 
 		assert.ok(membraneService.getActivity('autonomic') > before);
+	});
+
+	// --- Tiered storage (hybrid hot/cold hypergraph) tests ---
+
+	test('should archive nodes below the salience threshold and remove them from the live store', async () => {
+		hypergraphStore.addNode({
+			id: 'cold-node', node_type: 'T', content: 'stale', links: [], metadata: {}, salience_score: 0.01,
+		});
+		hypergraphStore.addNode({
+			id: 'hot-node', node_type: 'T', content: 'active', links: [], metadata: {}, salience_score: 0.9,
+		});
+
+		const result = await persistenceService.archiveLowSalienceNodes(0.05);
+
+		assert.strictEqual(result.archivedNodeCount, 1);
+		assert.strictEqual(result.archivedLinkCount, 0);
+		assert.strictEqual(hypergraphStore.getNode('cold-node'), undefined);
+		assert.ok(hypergraphStore.getNode('hot-node'), 'hot node should remain live');
+
+		const archived = await persistenceService.listArchivedNodes();
+		assert.strictEqual(archived.length, 1);
+		assert.strictEqual(archived[0].id, 'cold-node');
+	});
+
+	test('should archive a link only when every outgoing node is also archived', async () => {
+		hypergraphStore.addNode({
+			id: 'cold-a', node_type: 'T', content: '', links: ['fully-cold'], metadata: {}, salience_score: 0.01,
+		});
+		hypergraphStore.addNode({
+			id: 'cold-b', node_type: 'T', content: '', links: ['fully-cold'], metadata: {}, salience_score: 0.01,
+		});
+		hypergraphStore.addNode({
+			id: 'hot-c', node_type: 'T', content: '', links: ['partially-hot'], metadata: {}, salience_score: 0.9,
+		});
+		hypergraphStore.addNode({
+			id: 'cold-d', node_type: 'T', content: '', links: ['partially-hot'], metadata: {}, salience_score: 0.01,
+		});
+		hypergraphStore.addLink({ id: 'fully-cold', link_type: 'L', outgoing: ['cold-a', 'cold-b'], metadata: {} });
+		hypergraphStore.addLink({ id: 'partially-hot', link_type: 'L', outgoing: ['hot-c', 'cold-d'], metadata: {} });
+
+		const result = await persistenceService.archiveLowSalienceNodes(0.05);
+
+		assert.strictEqual(result.archivedNodeCount, 3);
+		assert.strictEqual(result.archivedLinkCount, 1);
+		assert.ok(hypergraphStore.getLink('fully-cold') === undefined, 'link fully within the archived set should be archived');
+		assert.ok(hypergraphStore.getLink('partially-hot'), 'link with a remaining hot endpoint should stay live');
+	});
+
+	test('should report zero archived when nothing is below the threshold', async () => {
+		hypergraphStore.addNode({
+			id: 'hot-only', node_type: 'T', content: '', links: [], metadata: {}, salience_score: 0.9,
+		});
+
+		const result = await persistenceService.archiveLowSalienceNodes(0.05);
+		assert.strictEqual(result.archivedNodeCount, 0);
+		assert.strictEqual(result.archivedLinkCount, 0);
+	});
+
+	test('should lazily restore a single archived node and its own links back into the live store', async () => {
+		hypergraphStore.addNode({
+			id: 'r-a', node_type: 'T', content: '', links: ['r-link'], metadata: {}, salience_score: 0.01,
+		});
+		hypergraphStore.addNode({
+			id: 'r-b', node_type: 'T', content: '', links: ['r-link'], metadata: {}, salience_score: 0.01,
+		});
+		hypergraphStore.addLink({ id: 'r-link', link_type: 'L', outgoing: ['r-a', 'r-b'], metadata: {} });
+		await persistenceService.archiveLowSalienceNodes(0.05);
+		assert.strictEqual(hypergraphStore.getNode('r-a'), undefined);
+
+		const restored = await persistenceService.restoreArchivedNode('r-a');
+
+		assert.ok(restored);
+		assert.strictEqual(restored!.id, 'r-a');
+		assert.ok(hypergraphStore.getNode('r-a'), 'node should be back in the live store');
+		assert.ok(hypergraphStore.getLink('r-link'), 'the restored node\'s own link should come back with it');
+
+		const archived = await persistenceService.listArchivedNodes();
+		assert.ok(!archived.some(n => n.id === 'r-a'), 'restored node should be removed from cold storage');
+	});
+
+	test('should return undefined restoring a node id that was never archived', async () => {
+		const restored = await persistenceService.restoreArchivedNode('never-archived');
+		assert.strictEqual(restored, undefined);
+	});
+
+	test('should include archived node count in persistence stats', async () => {
+		hypergraphStore.addNode({
+			id: 'stat-cold', node_type: 'T', content: '', links: [], metadata: {}, salience_score: 0.01,
+		});
+		await persistenceService.archiveLowSalienceNodes(0.05);
+
+		const stats = await persistenceService.getStats();
+		assert.strictEqual(stats.archivedNodeCount, 1);
 	});
 });
 


### PR DESCRIPTION
## Description

Continues the ZoneCog implementation plan tracked in #76. With Phase A (#77) and Phase B (#78) both closed, this picks up the next item in the epic's recommended order — Phase E, Enhanced Persistence Layer (#81) — specifically the "Hybrid Storage Strategy" (E.2) and part of the export enhancements (E.3):

- `HypergraphPersistenceService` gains tiered hot/cold storage: `archiveLowSalienceNodes(threshold?)` moves nodes whose `salience_score` is below a threshold (default `0.05`) out of the live in-memory hypergraph into a new IndexedDB cold tier (`archiveNodes`/`archiveLinks` object stores, DB bumped to version 2). A link is archived alongside its nodes only when *every* one of its outgoing ids is also being archived in the same pass, so links with a remaining hot endpoint stay live.
- `restoreArchivedNode(nodeId)` lazily restores a single archived node — and the links it directly references — back into the live hypergraph on demand, without materializing the rest of the cold tier.
- `listArchivedNodes()` browses cold-tier contents without loading them into memory.
- `getStats()` now reports `archivedNodeCount`.
- Two new Command Palette actions: **Zone-Cog: Archive Low-Salience Nodes** and **Zone-Cog: Restore Archived Node** (quick-pick over the archived set).

While auditing E.3 ("Export/Import Enhancements") I found Neo4j Cypher export and OpenCog AtomSpace Scheme export were already implemented in a prior PR but not reflected as complete in `docs/ZONECOG_ROADMAP.md`; that doc is updated accordingly, and the remaining E.1 (RocksDB-via-WASM backend) and the rest of E.3 (incremental backup/restore, cloud storage) are called out explicitly as future work — RocksDB in particular would need a new WASM dependency and build-system integration that's out of scope here, consistent with the epic's own risk assessment which already treats IndexedDB as the fallback.

Closes part of #81.

## Code Changes Checklist

- [x] New or updated **unit tests** added — 7 new tests covering archival (including partial-link-ownership), lazy restore, and stats reporting, plus IndexedDB mock support for `get`/`delete` and the two new object stores
- [ ] All existing tests pass (`npm run test`) — this sandbox has no `node_modules` available to run the full suite; verified instead with a scoped `tsc --noEmit` pass restricted to the touched files (zero errors) and careful manual review against the existing test harness patterns. Please confirm green in CI.
- [x] Code follows [contributing guidelines](https://github.com/microsoft/azuredatastudio/blob/main/CONTRIBUTING.md)
- [x] No UI regressions introduced — additive service methods and two new opt-in Command Palette actions only
- [ ] Logging/telemetry updated if applicable — n/a, uses existing `ILogService`/membrane activity recording patterns
- [x] Cross-platform support checked (Windows, macOS, Linux if relevant) — browser/IndexedDB-only code path, no platform-specific behavior

## Reviewers: [Please read our reviewer guidelines](https://github.com/microsoft/azuredatastudio/blob/main/.github/REVIEW_GUIDELINES.md)


---
_Generated by [Claude Code](https://claude.ai/code/session_018vEwvw9WpfuFHZAcKXAump)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hypergraph persistence semantics (IndexedDB schema v2, in-memory removals, restore/link edge cases); mitigated by serialization and extensive tests, but data-loss or inconsistency bugs would affect stored knowledge graphs.
> 
> **Overview**
> Adds **Phase E.2 hybrid storage** to `HypergraphPersistenceService`: low-salience nodes move from the live graph into IndexedDB **cold** stores (`archiveNodes` / `archiveLinks`, DB version 2), with `archiveLowSalienceNodes()`, lazy `restoreArchivedNode()`, and `listArchivedNodes()`. Links archive only when every outgoing endpoint is archived in the same pass; restore keeps shared cold links until no archived node still references them, and avoids writing links into the hot tier while an endpoint remains cold.
> 
> **Save**, **load**, **clear**, and archive/restore run through a **`_serialize` write queue** so concurrent auto-save cannot resurrect archived nodes. `getStats()` adds `archivedNodeCount`; `clearStorage()` wipes cold tiers too.
> 
> Two Command Palette actions expose archive and restore (quick-pick). `docs/ZONECOG_ROADMAP.md` documents completed Cypher/Scheme export and tiered storage; RocksDB and incremental/cloud backup stay future work. Broad unit tests cover tiering, hot-store durability, and save/archive races.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7ef3e4ce9a72db93284a40116b793e8fc0d1280. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->